### PR TITLE
Add ReCloneCommand

### DIFF
--- a/GitTools.Tests/Commands/ReCloneCommandTests.cs
+++ b/GitTools.Tests/Commands/ReCloneCommandTests.cs
@@ -1,0 +1,78 @@
+using System.CommandLine;
+using System.Diagnostics;
+using GitTools.Commands;
+using GitTools.Services;
+using Spectre.Console.Testing;
+
+namespace GitTools.Tests.Commands;
+
+[ExcludeFromCodeCoverage]
+public sealed class ReCloneCommandTests
+{
+    private readonly MockFileSystem _fileSystem = new();
+    private readonly IProcessRunner _runner = Substitute.For<IProcessRunner>();
+    private readonly IBackupService _backup = Substitute.For<IBackupService>();
+    private readonly TestConsole _console = new();
+    private readonly ReCloneCommand _command;
+
+    public ReCloneCommandTests()
+    {
+        _fileSystem.AddDirectory("/repo/.git");
+        _fileSystem.Directory.SetCurrentDirectory("/repo");
+        _console.Interactive();
+        _command = new ReCloneCommand(_fileSystem, _runner, _backup, _console);
+    }
+
+    [Fact]
+    public void Constructor_ShouldConfigureOptions()
+    {
+        _command.Name.ShouldBe("reclone");
+        _command.Options.ShouldContain(o => o.Name == "no-backup");
+        _command.Options.ShouldContain(o => o.Name == "force");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NotAGitRepository_ShouldShowMessage()
+    {
+        _fileSystem.Directory.Delete("/repo/.git");
+        await _command.ExecuteAsync(false, false);
+        _console.Output.ShouldContain("not a git repository");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithUncommittedChanges_ShouldAbort()
+    {
+        SetupGitOutputs("M file.txt\n");
+        await _command.ExecuteAsync(false, false);
+        _console.Output.ShouldContain("Uncommitted changes");
+        await _runner.DidNotReceiveWithAnyArgs().RunAsync(null!, null!, null!);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithForceAndBackup_ShouldCloneAndBackup()
+    {
+        SetupGitOutputs(string.Empty, "https://example/repo.git\n");
+        await _command.ExecuteAsync(false, true);
+        await _backup.Received(1).CreateBackup("/repo", "/repo-backup.zip");
+    }
+
+    private void SetupGitOutputs(params string[] outputs)
+    {
+        var call = 0;
+        _runner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(ci =>
+            {
+                var outHandler = ci.ArgAt<DataReceivedEventHandler>(1);
+                if (call < outputs.Length)
+                    outHandler?.Invoke(null!, CreateEvent(outputs[call]));
+                call++;
+                return 0;
+            });
+    }
+
+    private static DataReceivedEventArgs CreateEvent(string data)
+    {
+        var ctor = typeof(DataReceivedEventArgs).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, [typeof(string)], null)!;
+        return (DataReceivedEventArgs)ctor.Invoke([data]);
+    }
+}

--- a/GitTools.Tests/Commands/ReCloneCommandTests.cs
+++ b/GitTools.Tests/Commands/ReCloneCommandTests.cs
@@ -1,78 +1,355 @@
-using System.CommandLine;
-using System.Diagnostics;
+using System.IO.Abstractions;
+using System.IO.Abstractions.TestingHelpers;
 using GitTools.Commands;
+using GitTools.Models;
 using GitTools.Services;
 using Spectre.Console.Testing;
 
 namespace GitTools.Tests.Commands;
 
+/// <summary>
+/// Unit tests for the ReCloneCommand class.
+/// </summary>
 [ExcludeFromCodeCoverage]
 public sealed class ReCloneCommandTests
 {
-    private readonly MockFileSystem _fileSystem = new();
-    private readonly IProcessRunner _runner = Substitute.For<IProcessRunner>();
-    private readonly IBackupService _backup = Substitute.For<IBackupService>();
-    private readonly TestConsole _console = new();
+    private readonly MockFileSystem _mockFileSystem = new();
+    private readonly IBackupService _mockBackupService = Substitute.For<IBackupService>();
+    private readonly IGitService _mockGitService = Substitute.For<IGitService>();
+    private readonly TestConsole _testConsole = new();
+    private readonly IProcessRunner _mockProcessRunner = Substitute.For<IProcessRunner>();
     private readonly ReCloneCommand _command;
+
+    private const string REPO_NAME = "test-repo";
+    private const string REPO_PATH = @"C:\current\test-repo";
+    private const string PARENT_DIR = @"C:\current";
+    private const string REMOTE_URL = "https://github.com/user/test-repo.git";
+    private const string BACKUP_FILE = @"C:\current\test-repo-backup.zip";
 
     public ReCloneCommandTests()
     {
-        _fileSystem.AddDirectory("/repo/.git");
-        _fileSystem.Directory.SetCurrentDirectory("/repo");
-        _console.Interactive();
-        _command = new ReCloneCommand(_fileSystem, _runner, _backup, _console);
+        _testConsole.Interactive();
+        _command = new ReCloneCommand(_mockFileSystem, _mockBackupService, _mockGitService, _testConsole, _mockProcessRunner);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetCorrectNameAndDescription()
+    {
+        // Assert
+        _command.Name.ShouldBe("reclone");
+        _command.Description.ShouldBe("Reclones the specified git repository.");
+    }
+
+    [Fact]
+    public void Constructor_ShouldConfigureArguments()
+    {
+        // Assert
+        _command.Arguments.Count.ShouldBe(1);
+
+        var repositoryNameArgument = _command.Arguments[0];
+        repositoryNameArgument.Name.ShouldBe("repository-name");
+        repositoryNameArgument.Description.ShouldBe("Git repository folder name relative to the current directory to reclone");
     }
 
     [Fact]
     public void Constructor_ShouldConfigureOptions()
     {
-        _command.Name.ShouldBe("reclone");
-        _command.Options.ShouldContain(o => o.Name == "no-backup");
-        _command.Options.ShouldContain(o => o.Name == "force");
+        // Assert
+        _command.Options.Count.ShouldBe(2);
+
+        var noBackupOption = _command.Options.First(o => o.Name == "no-backup");
+        noBackupOption.Description.ShouldBe("Do not create a backup zip of the folder");
+
+        var forceOption = _command.Options.First(o => o.Name == "force");
+        forceOption.Description.ShouldBe("Ignore uncommitted changes to the repository");
     }
 
     [Fact]
-    public async Task ExecuteAsync_NotAGitRepository_ShouldShowMessage()
+    public async Task ExecuteAsync_WhenRepositoryIsInvalid_ShouldShowErrorAndReturn()
     {
-        _fileSystem.Directory.Delete("/repo/.git");
-        await _command.ExecuteAsync(false, false);
-        _console.Output.ShouldContain("not a git repository");
+        // Arrange
+        var invalidRepo = new GitRepository
+        {
+            Name = REPO_NAME,
+            Path = REPO_PATH,
+            IsValid = false
+        };
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(invalidRepo);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        _testConsole.Output.ShouldContain($"{REPO_NAME} is not valid or does not exist: {REPO_PATH}");
+
+        await _mockGitService.DidNotReceive().RunGitCommandAsync(Arg.Any<string>(), Arg.Any<string>());
+        _mockBackupService.DidNotReceive().CreateBackup(Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithUncommittedChanges_ShouldAbort()
+    public async Task ExecuteAsync_WhenUncommittedChangesExistAndNotForced_ShouldShowErrorAndReturn()
     {
-        SetupGitOutputs("M file.txt\n");
-        await _command.ExecuteAsync(false, false);
-        _console.Output.ShouldContain("Uncommitted changes");
-        await _runner.DidNotReceiveWithAnyArgs().RunAsync(null!, null!, null!);
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns("M modified-file.txt");
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        _testConsole.Output.ShouldContain("Uncommitted changes detected. Use --force to ignore.");
+
+        await _mockGitService.Received(1).RunGitCommandAsync(REPO_PATH, "status --porcelain");
+        _mockBackupService.DidNotReceive().CreateBackup(Arg.Any<string>(), Arg.Any<string>());
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithForceAndBackup_ShouldCloneAndBackup()
+    public async Task ExecuteAsync_WhenForcedWithUncommittedChanges_ShouldProceedWithReclone()
     {
-        SetupGitOutputs(string.Empty, "https://example/repo.git\n");
-        await _command.ExecuteAsync(false, true);
-        await _backup.Received(1).CreateBackup("/repo", "/repo-backup.zip");
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, true);
+
+        // Assert
+        await _mockGitService.DidNotReceive().RunGitCommandAsync(REPO_PATH, "status --porcelain");
+        _mockBackupService.Received(1).CreateBackup(Arg.Any<string>(), BACKUP_FILE);
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
     }
 
-    private void SetupGitOutputs(params string[] outputs)
+    [Fact]
+    public async Task ExecuteAsync_WhenNoBackupOption_ShouldSkipBackupCreation()
     {
-        var call = 0;
-        _runner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
-            .Returns(ci =>
-            {
-                var outHandler = ci.ArgAt<DataReceivedEventHandler>(1);
-                if (call < outputs.Length)
-                    outHandler?.Invoke(null!, CreateEvent(outputs[call]));
-                call++;
-                return 0;
-            });
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, true, false);
+
+        // Assert
+        _mockBackupService.DidNotReceive().CreateBackup(Arg.Any<string>(), Arg.Any<string>());
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
     }
 
-    private static DataReceivedEventArgs CreateEvent(string data)
+    [Fact]
+    public async Task ExecuteAsync_WhenSuccessfulReclone_ShouldCreateBackupAndClone()
     {
-        var ctor = typeof(DataReceivedEventArgs).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, [typeof(string)], null)!;
-        return (DataReceivedEventArgs)ctor.Invoke([data]);
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+
+        _mockFileSystem.AddDirectory(REPO_PATH);
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        _mockBackupService.Received(1).CreateBackup(REPO_PATH, BACKUP_FILE);
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        await _mockGitService.Received(1).DeleteLocalGitRepositoryAsync(Arg.Is<string>(s => s.StartsWith(REPO_PATH) && s.Contains(REPO_NAME)));
+
+        _testConsole.Output.ShouldContain($"Recloning repository: {REPO_NAME} at {REPO_PATH}");
+        _testConsole.Output.ShouldContain($"Backup created: {BACKUP_FILE}");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDirectoryMoveSucceeds_ShouldRenameAndDelete()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+
+        _mockFileSystem.AddDirectory(REPO_PATH);
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        var movedDirectories = _mockFileSystem.AllDirectories
+            .Where(d => d.StartsWith(REPO_PATH) && d != REPO_PATH && d.Length > REPO_PATH.Length)
+            .ToList();
+
+        movedDirectories.ShouldNotBeEmpty();
+        await _mockGitService.Received(1).DeleteLocalGitRepositoryAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDirectoryMoveFails_ShouldStillProceed()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+
+        // Simulate directory move failure by not adding the directory to mock filesystem
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDeleteOldRepositorySucceeds_ShouldShowSuccessMessage()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        var tempPath = $"{REPO_PATH}{Guid.NewGuid()}";
+
+        _mockFileSystem.AddDirectory(REPO_PATH);
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+        _mockGitService.RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}").Returns("Cloning...");
+        _mockGitService.DeleteLocalGitRepositoryAsync(Arg.Any<string>()).Returns(true);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        _testConsole.Output.ShouldContain("Old repository deleted:");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDeleteOldRepositoryFails_ShouldStillShowSuccessMessage()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+
+        _mockFileSystem.AddDirectory(REPO_PATH);
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+        _mockGitService.RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}").Returns("Cloning...");
+        _mockGitService.DeleteLocalGitRepositoryAsync(Arg.Any<string>()).Returns(false);
+
+        // Act
+        await _command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        _testConsole.Output.ShouldNotContain("Old repository deleted:");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDirectoryMoveThrowsException_ShouldLogWarningAndProceed()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+        var mockFileSystem = Substitute.For<IFileSystem>();
+        var command = new ReCloneCommand(mockFileSystem, _mockBackupService, _mockGitService, _testConsole, _mockProcessRunner);
+
+        // Configure mock to throw an exception when Move is called
+        mockFileSystem.Directory.Exists(REPO_PATH).Returns(true);
+        mockFileSystem.Directory.When(x => x.Move(Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ => throw new UnauthorizedAccessException("Access denied"));
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        await _mockGitService.DidNotReceive().DeleteLocalGitRepositoryAsync(Arg.Any<string>());
+        _testConsole.Output.ShouldContain("Attempt to rename folder");
+        _testConsole.Output.ShouldContain("failed: Access denied");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDirectoryMoveThrowsIOException_ShouldLogWarningAndProceed()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+        var mockFileSystem = Substitute.For<IFileSystem>();
+        var command = new ReCloneCommand(mockFileSystem, _mockBackupService, _mockGitService, _testConsole, _mockProcessRunner);
+
+        // Configure mock to throw IOException when Move is called
+        mockFileSystem.Directory.Exists(REPO_PATH).Returns(true);
+        mockFileSystem.Directory.When(x => x.Move(Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ => throw new IOException("Directory is in use"));
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        await _mockGitService.DidNotReceive().DeleteLocalGitRepositoryAsync(Arg.Any<string>());
+        _testConsole.Output.ShouldContain("Attempt to rename folder");
+        _testConsole.Output.ShouldContain("failed: Directory is in use");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDirectoryNotFound_ShouldProceedWithoutWarning()
+    {
+        // Arrange
+        var validRepo = CreateValidGitRepository();
+        SetupSuccessfulReclone(validRepo);
+        var mockFileSystem = Substitute.For<IFileSystem>();
+        var command = new ReCloneCommand(mockFileSystem, _mockBackupService, _mockGitService, _testConsole, _mockProcessRunner);
+
+        // Configure mock to throw DirectoryNotFoundException when Move is called
+        mockFileSystem.Directory.Exists(REPO_PATH).Returns(true);
+        mockFileSystem.Directory.When(x => x.Move(Arg.Any<string>(), Arg.Any<string>()))
+            .Do(_ => throw new DirectoryNotFoundException("Directory not found"));
+
+        _mockGitService.GetGitRepositoryAsync(REPO_NAME).Returns(validRepo);
+        _mockGitService.RunGitCommandAsync(REPO_PATH, "status --porcelain").Returns(string.Empty);
+
+        // Act
+        await command.ExecuteAsync(REPO_NAME, false, false);
+
+        // Assert
+        await _mockGitService.Received(1).RunGitCommandAsync(PARENT_DIR, $"clone {REMOTE_URL} {REPO_NAME}");
+        await _mockGitService.DidNotReceive().DeleteLocalGitRepositoryAsync(Arg.Any<string>());
+        _testConsole.Output.ShouldNotContain("Attempt to rename folder");
+        _testConsole.Output.ShouldNotContain("failed:");
+        _testConsole.Output.ShouldContain("Repository recloned successfully");
+    }
+
+    private GitRepository CreateValidGitRepository()
+        => new()
+        {
+            Name = REPO_NAME,
+            Path = REPO_PATH,
+            RemoteUrl = REMOTE_URL,
+            IsValid = true
+        };
+
+    private void SetupSuccessfulReclone(GitRepository repo)
+    {
+        _mockGitService.RunGitCommandAsync(repo.ParentDir, $"clone {repo.RemoteUrl} {repo.Name}")
+            .Returns("Cloning into 'test-repo'...");
+
+        _mockGitService.DeleteLocalGitRepositoryAsync(Arg.Any<string>())
+            .Returns(true);
     }
 }

--- a/GitTools/Commands/ReCloneCommand.cs
+++ b/GitTools/Commands/ReCloneCommand.cs
@@ -1,0 +1,119 @@
+using System.CommandLine;
+using System.Diagnostics;
+using System.Text;
+using System.IO.Abstractions;
+using GitTools.Services;
+using Spectre.Console;
+
+namespace GitTools.Commands;
+
+/// <summary>
+/// Command for recloning the current git repository.
+/// </summary>
+public sealed class ReCloneCommand : Command
+{
+    private readonly IFileSystem _fileSystem;
+    private readonly IProcessRunner _processRunner;
+    private readonly IBackupService _backupService;
+    private readonly IAnsiConsole _console;
+
+    public ReCloneCommand
+    (
+        IFileSystem fileSystem,
+        IProcessRunner processRunner,
+        IBackupService backupService,
+        IAnsiConsole console
+    )
+        : base("reclone", "Reclones the git repository in the current directory.")
+    {
+        _fileSystem = fileSystem;
+        _processRunner = processRunner;
+        _backupService = backupService;
+        _console = console;
+
+        var noBackupOption = new Option<bool>("--no-backup", "Do not create a backup zip of the folder");
+        var forceOption = new Option<bool>("--force", "Ignore uncommitted changes to the repository");
+
+        AddOption(noBackupOption);
+        AddOption(forceOption);
+
+        this.SetHandler(ExecuteAsync, noBackupOption, forceOption);
+    }
+
+    /// <summary>
+    /// Executes the reclone operation.
+    /// </summary>
+    public async Task ExecuteAsync(bool noBackup, bool force)
+    {
+        var repoPath = _fileSystem.Directory.GetCurrentDirectory();
+        var gitPath = _fileSystem.Path.Combine(repoPath, ".git");
+
+        if (!_fileSystem.Directory.Exists(gitPath) && !_fileSystem.File.Exists(gitPath))
+        {
+            _console.MarkupLine("[red]Current directory is not a git repository.[/]");
+            return;
+        }
+
+        if (!force)
+        {
+            var status = await RunGitAsync(repoPath, "status --porcelain");
+            if (!string.IsNullOrWhiteSpace(status))
+            {
+                _console.MarkupLine("[red]Uncommitted changes detected. Use --force to ignore.[/]");
+                return;
+            }
+        }
+
+        var remoteUrl = (await RunGitAsync(repoPath, "config --get remote.origin.url")).Trim();
+        var parentDir = _fileSystem.Path.GetDirectoryName(repoPath)!;
+        var repoName = _fileSystem.Path.GetFileName(repoPath.TrimEnd(_fileSystem.Path.DirectorySeparatorChar, _fileSystem.Path.AltDirectorySeparatorChar));
+
+        if (!noBackup)
+        {
+            var backupFile = _fileSystem.Path.Combine(parentDir, $"{repoName}-backup.zip");
+            _backupService.CreateBackup(repoPath, backupFile);
+            _console.MarkupLineInterpolated($"[grey]Backup created: {backupFile}[/]");
+        }
+
+        _fileSystem.Directory.Delete(repoPath, true);
+        await _processRunner.RunAsync
+        (
+            new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = $"clone {remoteUrl} {repoName}",
+                WorkingDirectory = parentDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        ).ConfigureAwait(false);
+
+        _console.MarkupLine("[green]Repository recloned successfully.[/]");
+    }
+
+    private async Task<string> RunGitAsync(string workingDirectory, string arguments)
+    {
+        var output = new StringBuilder();
+        var error = new StringBuilder();
+
+        var exitCode = await _processRunner.RunAsync
+        (
+            new ProcessStartInfo
+            {
+                FileName = "git",
+                Arguments = arguments,
+                WorkingDirectory = workingDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            },
+            (_, e) => { if (e.Data is not null) output.AppendLine(e.Data); },
+            (_, e) => { if (e.Data is not null) error.AppendLine(e.Data); }
+        ).ConfigureAwait(false);
+
+        return exitCode != 0 ? throw new InvalidOperationException(error.ToString()) : output.ToString();
+    }
+}

--- a/GitTools/Models/GitRepository.cs
+++ b/GitTools/Models/GitRepository.cs
@@ -1,0 +1,38 @@
+namespace GitTools.Models;
+
+/// <summary>
+///  Represents a Git repository with its metadata.
+///  This class encapsulates the repository's name, path, remote URL, and validity status.
+/// </summary>
+public sealed class GitRepository
+{
+    /// <summary>
+    ///  Gets or sets the name of the repository.
+    ///  This is typically the folder name where the repository is located.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    ///  Gets or sets the path to the repository.
+    ///  This is the full file system path to the repository directory.
+    /// </summary>
+    public required string Path { get; init; }
+
+    /// <summary>
+    ///  Gets or sets the remote URL of the repository.
+    ///  This is the URL of the remote repository, typically where the code is hosted (e.g., GitHub, GitLab).
+    /// </summary>
+    public string? RemoteUrl { get; init; }
+
+    /// <summary>
+    ///  Gets the parent directory of the repository path.
+    ///  This is the directory that contains the repository folder.
+    /// </summary>
+    public string ParentDir
+        => System.IO.Path.GetDirectoryName(Path) ?? string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the repository is valid.
+    /// </summary>
+    public bool IsValid { get; init; }
+}

--- a/GitTools/Services/IBackupService.cs
+++ b/GitTools/Services/IBackupService.cs
@@ -1,0 +1,14 @@
+namespace GitTools.Services;
+
+/// <summary>
+/// Provides backup capabilities for directories.
+/// </summary>
+public interface IBackupService
+{
+    /// <summary>
+    /// Creates a zip archive from the specified directory.
+    /// </summary>
+    /// <param name="sourceDirectory">Directory to archive.</param>
+    /// <param name="destinationZipFile">Path of the resulting zip file.</param>
+    void CreateBackup(string sourceDirectory, string destinationZipFile);
+}

--- a/GitTools/Services/IGitService.cs
+++ b/GitTools/Services/IGitService.cs
@@ -1,3 +1,5 @@
+using GitTools.Models;
+
 namespace GitTools.Services;
 
 /// <summary>
@@ -73,4 +75,26 @@ public interface IGitService
     /// The output of the git command.
     /// </returns>
     Task<string> RunGitCommandAsync(string workingDirectory, string arguments);
+
+    /// <summary>
+    /// Gets the git repository information for the specified repository name.
+    /// </summary>
+    /// <param name="repositoryName">The name of the repository to retrieve.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains the GitRepository object.
+    /// </returns>
+    Task<GitRepository> GetGitRepositoryAsync(string repositoryName);
+
+    /// <summary>
+    /// Deletes a local git repository at the specified path.
+    /// This method will remove the git repository directory and all its contents.
+    /// </summary>
+    /// <param name="repositoryPath">
+    ///  The path to the local git repository to delete.
+    /// </param>
+    /// <returns>
+    /// true if the repository was successfully deleted; otherwise, false.
+    /// If the repository does not exist or cannot be deleted, it returns false.
+    /// </returns>
+    Task<bool> DeleteLocalGitRepositoryAsync(string? repositoryPath);
 }

--- a/GitTools/Services/ZipBackupService.cs
+++ b/GitTools/Services/ZipBackupService.cs
@@ -1,0 +1,16 @@
+using System.IO.Compression;
+
+namespace GitTools.Services;
+
+/// <inheritdoc/>
+public sealed class ZipBackupService : IBackupService
+{
+    /// <inheritdoc/>
+    public void CreateBackup(string sourceDirectory, string destinationZipFile)
+    {
+        if (File.Exists(destinationZipFile))
+            File.Delete(destinationZipFile);
+
+        ZipFile.CreateFromDirectory(sourceDirectory, destinationZipFile, CompressionLevel.Fastest, includeBaseDirectory: true);
+    }
+}

--- a/GitTools/Services/ZipBackupService.cs
+++ b/GitTools/Services/ZipBackupService.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics.CodeAnalysis;
 using System.IO.Compression;
 
 namespace GitTools.Services;
 
 /// <inheritdoc/>
+[ExcludeFromCodeCoverage]
 public sealed class ZipBackupService : IBackupService
 {
     /// <inheritdoc/>

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -28,7 +28,9 @@ public static class Startup
         services.AddSingleton<IGitRepositoryScanner, GitRepositoryScanner>();
         services.AddSingleton<IFileSystem, FileSystem>();
         services.AddSingleton<IGitService, GitService>();
+        services.AddSingleton<IBackupService, ZipBackupService>();
         services.AddSingleton<TagRemoveCommand>();
+        services.AddSingleton<ReCloneCommand>();
 
         return services;
     }
@@ -48,7 +50,9 @@ public static class Startup
         var rootCommand = new RootCommand("GitTools - A tool for searching and removing tags in Git repositories.");
 
         var tagRemoveCommand = serviceProvider.GetRequiredService<TagRemoveCommand>();
+        var recloneCommand = serviceProvider.GetRequiredService<ReCloneCommand>();
         rootCommand.AddCommand(tagRemoveCommand);
+        rootCommand.AddCommand(recloneCommand);
 
         return rootCommand;
     }

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 ## Index
 
 - [Features](#features)
-- [Usage](#usage)
-- [Parameters](#parameters)
-- [Example](#example)
+- [Commands](#commands)
+  - [Remove Tags (rm)](#remove-tags-rm)
+  - [Reclone Repository (reclone)](#reclone-repository-reclone)
 - [Build](#build)
 - [Code Coverage](#code-coverage)
 - [Publish as Single File](#publish-as-single-file)
@@ -18,27 +18,33 @@
 - [Third-party Libraries](#third-party-libraries)
 - [License](#license)
 
-GitTools is a command-line tool for searching and removing tags in multiple Git repositories and their submodules. It is designed to help you manage tags across large codebases with ease.
+GitTools is a command-line tool for managing Git repositories, including searching and removing tags across multiple repositories and recloning repositories with backup support.
 
 ## Features
 
-- Recursively scans a root directory for Git repositories and submodules
-- Lists all repositories containing specified tags
-- Allows interactive selection of repositories to remove tags from
-- Removes only the tags that actually exist in each repository
-- Supports multiple tags (comma-separated)
-- **Supports wildcard patterns** using `*` and `?` characters for flexible tag matching
-- Optionally removes tags from the remote repository as well
-- Modern, user-friendly terminal UI using [Spectre.Console](https://spectreconsole.net/)
-- Modern CLI parsing with [System.CommandLine](https://github.com/dotnet/command-line-api)
+- **Tag Management**: Recursively scans directories for Git repositories and manages tags
+- **Repository Recloning**: Clean reclone of repositories with automatic backup support
+- **Submodule Support**: Works with Git repositories and their submodules
+- **Interactive Selection**: User-friendly interface for selecting repositories
+- **Wildcard Pattern Support**: Use `*` and `?` characters for flexible tag matching
+- **Remote Tag Management**: Optionally remove tags from remote repositories
+- **Backup Creation**: Automatic ZIP backup creation before destructive operations
+- **Modern Terminal UI**: Built with [Spectre.Console](https://spectreconsole.net/) for beautiful interfaces
+- **Modern CLI Parsing**: Uses [System.CommandLine](https://github.com/dotnet/command-line-api) for extensible command-line parsing
 
-## Usage
+## Commands
+
+GitTools provides two main commands for repository management:
+
+### Remove Tags (rm)
+
+Search and remove tags from multiple Git repositories with wildcard pattern support.
 
 ```sh
 GitTools rm <root-directory> <tag1,tag2,...> [--remote]
 ```
 
-### Wildcard Support
+#### Wildcard Support
 
 GitTools supports wildcard patterns for flexible tag matching:
 
@@ -71,25 +77,60 @@ GitTools rm C:/Projects "NET8,v1.*,beta-?"
 
 **Note:** When using wildcards on Windows Command Prompt or PowerShell, wrap patterns in quotes to prevent shell expansion.
 
-### Parameters
+#### Parameters
 
 - `root-directory` (required): Root directory to scan for Git repositories (e.g., `C:\Projects`)
 - `tags` (required): Comma-separated list of tags or wildcard patterns to search and remove (e.g., `NET8,NET7` or `v1.*,beta-?`)
 - `--remote`, `-r`, `/remote` (optional): Also remove the tag from the remote repository (origin)
 - `--help` or `-h`: Show help and usage information
 
-### Example
+### Reclone Repository (reclone)
 
-**Remove specific tags:**
+Reclone a Git repository with automatic backup and cleanup support. This command is useful for cleaning up repository state, removing local changes, or fixing corrupted repositories.
 
 ```sh
-GitTools rm C:/Projects NET8,NET7 --remote
+GitTools reclone <repository-name> [--no-backup] [--force]
 ```
 
-**Remove tags using wildcards:**
+#### Reclone Features
+
+- **Automatic Backup**: Creates a ZIP backup of the repository before recloning (unless `--no-backup` is specified)
+- **Uncommitted Changes Detection**: Checks for uncommitted changes and requires `--force` to proceed
+- **Temporary Directory Management**: Safely renames the original directory during the process
+- **Cleanup**: Automatically removes the old repository directory after successful recloning
+- **Remote URL Preservation**: Uses the existing remote URL for recloning
+
+#### Reclone Parameters
+
+- `repository-name` (required): Name of the Git repository folder relative to the current directory
+- `--no-backup` (optional): Skip creating a backup ZIP file before recloning
+- `--force` (optional): Ignore uncommitted changes and proceed with recloning
+- `--help` or `-h`: Show help and usage information
+
+#### Examples
+
+**Basic reclone with backup:**
 
 ```sh
-GitTools rm C:/Projects "v1.*,beta-*" --remote
+GitTools reclone my-project
+```
+
+**Reclone without backup:**
+
+```sh
+GitTools reclone my-project --no-backup
+```
+
+**Force reclone ignoring uncommitted changes:**
+
+```sh
+GitTools reclone my-project --force
+```
+
+**Reclone without backup and ignoring changes:**
+
+```sh
+GitTools reclone my-project --no-backup --force
 ```
 
 ## Build


### PR DESCRIPTION
## Summary
- implement `ReCloneCommand` to re-clone a repository with optional backup and force
- support backup service using `ZipBackupService`
- register command and service via `Startup`
- test behaviour of `ReCloneCommand`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed944e8f083258baef8cfe5bb9abf