### PR TITLE
Add tag listing command

### DIFF
--- a/GitTools.Tests/Commands/TagListCommandTests.cs
+++ b/GitTools.Tests/Commands/TagListCommandTests.cs
@@ -1,0 +1,100 @@
+using System.CommandLine;
+using GitTools.Commands;
+using GitTools.Services;
+using Spectre.Console.Testing;
+
+namespace GitTools.Tests.Commands;
+
+[ExcludeFromCodeCoverage]
+public sealed class TagListCommandTests
+{
+    private readonly IGitRepositoryScanner _mockGitScanner = Substitute.For<IGitRepositoryScanner>();
+    private readonly IGitService _mockGitService = Substitute.For<IGitService>();
+    private readonly TestConsole _testConsole = new();
+    private readonly TagListCommand _command;
+
+    public TagListCommandTests()
+    {
+        _testConsole.Interactive();
+        _command = new TagListCommand(_mockGitScanner, _mockGitService, _testConsole);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetCorrectNameAndDescription()
+    {
+        _command.Name.ShouldBe("ls");
+        _command.Description.ShouldBe("Lists repositories containing specified tags.");
+    }
+
+    [Fact]
+    public void Constructor_ShouldConfigureArguments()
+    {
+        _command.Arguments.Count.ShouldBe(2);
+
+        var dirArg = _command.Arguments[0];
+        dirArg.Name.ShouldBe("directory");
+        dirArg.Description.ShouldBe("Root directory of git repositories");
+
+        var tagsArg = _command.Arguments[1];
+        tagsArg.Name.ShouldBe("tags");
+        tagsArg.Description.ShouldBe("Tags to search (comma separated)");
+        tagsArg.Arity.ShouldBe(ArgumentArity.ExactlyOne);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithEmptyTags_ShouldShowMessage()
+    {
+        await _command.ExecuteAsync("  ", "C:/repos");
+
+        _testConsole.Output.ShouldContain("No tags specified to search.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNoRepositories_ShouldShowMessage()
+    {
+        _mockGitScanner.Scan("C:/repos").Returns([]);
+
+        await _command.ExecuteAsync("v1.0", "C:/repos");
+
+        _testConsole.Output.ShouldContain("No Git repositories found.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMatchingRepositories_ShouldListThem()
+    {
+        var repos = new List<string> { "C:/repos/repo1" };
+        _mockGitScanner.Scan("C:/repos").Returns(repos);
+        _mockGitService.GetAllTagsAsync("C:/repos/repo1").Returns(["v1.0", "v2.0"]);
+
+        await _command.ExecuteAsync("v1.0", "C:/repos");
+
+        _testConsole.Output.ShouldContain("repo1");
+        _testConsole.Output.ShouldContain("v1.0");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithWildcardPatterns_ShouldFilter()
+    {
+        var repos = new List<string> { "C:/repos/repo1" };
+        _mockGitScanner.Scan("C:/repos").Returns(repos);
+        _mockGitService.GetAllTagsAsync("C:/repos/repo1").Returns(["v1.0", "v2.0", "feature"]);
+
+        await _command.ExecuteAsync("v1.*", "C:/repos");
+
+        _testConsole.Output.ShouldContain("v1.0");
+        _testConsole.Output.ShouldNotContain("v2.0");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithScanErrors_ShouldPromptAndDisplay()
+    {
+        var repos = new List<string> { "C:/repos/repo1" };
+        _mockGitScanner.Scan("C:/repos").Returns(repos);
+        _mockGitService.GetAllTagsAsync("C:/repos/repo1").Throws(new Exception("boom"));
+        _testConsole.Input.PushTextWithEnter("y");
+
+        await _command.ExecuteAsync("v1.0", "C:/repos");
+
+        _testConsole.Output.ShouldContain("boom");
+    }
+}

--- a/GitTools/Commands/TagListCommand.cs
+++ b/GitTools/Commands/TagListCommand.cs
@@ -1,0 +1,122 @@
+using System.CommandLine;
+using GitTools.Services;
+using GitTools.Utils;
+using Spectre.Console;
+
+namespace GitTools.Commands;
+
+/// <summary>
+/// Command for listing repositories that contain specified tags.
+/// </summary>
+public sealed class TagListCommand : Command
+{
+    private readonly IGitRepositoryScanner _gitScanner;
+    private readonly IGitService _gitService;
+    private readonly IAnsiConsole _console;
+
+    public TagListCommand(
+        IGitRepositoryScanner gitScanner,
+        IGitService gitService,
+        IAnsiConsole console)
+        : base("ls", "Lists repositories containing specified tags.")
+    {
+        _gitScanner = gitScanner;
+        _gitService = gitService;
+        _console = console;
+
+        var dirArgument = new Argument<string>("directory", "Root directory of git repositories");
+        var tagsArgument = new Argument<string>("tags", "Tags to search (comma separated)")
+        {
+            Arity = ArgumentArity.ExactlyOne
+        };
+
+        AddArgument(dirArgument);
+        AddArgument(tagsArgument);
+
+        this.SetHandler(ExecuteAsync, tagsArgument, dirArgument);
+    }
+
+    /// <summary>
+    /// Executes the tag listing operation.
+    /// </summary>
+    public async Task ExecuteAsync(string tags, string baseFolder)
+    {
+        var patterns = tags.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+        if (patterns.Length == 0)
+        {
+            _console.MarkupLine("[red]No tags specified to search.[/]");
+            return;
+        }
+
+        var allGitFolders = _gitScanner.Scan(baseFolder);
+
+        if (allGitFolders.Count == 0)
+        {
+            _console.MarkupLine("[red]No Git repositories found.[/]");
+            return;
+        }
+
+        var repoTagsMap = new Dictionary<string, List<string>>();
+        var scanErrors = new Dictionary<string, Exception>();
+
+        foreach (var repo in allGitFolders)
+        {
+            try
+            {
+                var allTags = await _gitService.GetAllTagsAsync(repo).ConfigureAwait(false);
+                var matches = new List<string>();
+                foreach (var pattern in patterns)
+                    matches.AddRange(WildcardMatcher.MatchItems(allTags, pattern));
+
+                matches = [.. matches.Distinct()];
+                if (matches.Count > 0)
+                    repoTagsMap[repo] = matches;
+            }
+            catch (Exception ex)
+            {
+                scanErrors[repo] = ex;
+            }
+        }
+
+        if (repoTagsMap.Count == 0)
+        {
+            _console.MarkupLine("[yellow]No repository with the specified tag(s) found.[/]");
+            ShowScanErrors(scanErrors, baseFolder);
+            return;
+        }
+
+        foreach (var (repo, tagsFound) in repoTagsMap)
+        {
+            var hierarchicalName = GetHierarchicalName(repo, baseFolder);
+            _console.MarkupLineInterpolated($"[blue]{hierarchicalName}[/]: {string.Join(", ", tagsFound)}");
+        }
+
+        ShowScanErrors(scanErrors, baseFolder);
+    }
+
+    private void ShowScanErrors(Dictionary<string, Exception> scanErrors, string baseFolder)
+    {
+        if (scanErrors.Count == 0)
+            return;
+
+        if (!_console.Confirm($"[red]{scanErrors.Count} scan errors detected.Do you want to see the details?[/]"))
+            return;
+
+        foreach (var err in scanErrors)
+        {
+            var rule = new Rule($"[red]{GetHierarchicalName(err.Key, baseFolder)}[/]")
+                .RuleStyle(new Style(Color.Red))
+                .Centered();
+
+            _console.Write(rule);
+            _console.WriteException(err.Value, ExceptionFormats.ShortenEverything);
+        }
+    }
+
+    private static string GetHierarchicalName(string repoPath, string baseFolder)
+    {
+        var relativePath = Path.GetRelativePath(baseFolder, repoPath).Replace(Path.DirectorySeparatorChar, '/');
+        return relativePath.Length <= 1 ? Path.GetFileName(repoPath) : relativePath;
+    }
+}

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -30,6 +30,7 @@ public static class Startup
         services.AddSingleton<IGitService, GitService>();
         services.AddSingleton<IBackupService, ZipBackupService>();
         services.AddSingleton<TagRemoveCommand>();
+        services.AddSingleton<TagListCommand>();
         services.AddSingleton<ReCloneCommand>();
 
         return services;
@@ -50,8 +51,10 @@ public static class Startup
         var rootCommand = new RootCommand("GitTools - A tool for searching and removing tags in Git repositories.");
 
         var tagRemoveCommand = serviceProvider.GetRequiredService<TagRemoveCommand>();
+        var tagListCommand = serviceProvider.GetRequiredService<TagListCommand>();
         var recloneCommand = serviceProvider.GetRequiredService<ReCloneCommand>();
         rootCommand.AddCommand(tagRemoveCommand);
+        rootCommand.AddCommand(tagListCommand);
         rootCommand.AddCommand(recloneCommand);
 
         return rootCommand;

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - [Features](#features)
 - [Commands](#commands)
   - [Remove Tags (rm)](#remove-tags-rm)
+  - [List Tags (ls)](#list-tags-ls)
   - [Reclone Repository (reclone)](#reclone-repository-reclone)
 - [Build](#build)
 - [Code Coverage](#code-coverage)
@@ -28,13 +29,14 @@ GitTools is a command-line tool for managing Git repositories, including searchi
 - **Interactive Selection**: User-friendly interface for selecting repositories
 - **Wildcard Pattern Support**: Use `*` and `?` characters for flexible tag matching
 - **Remote Tag Management**: Optionally remove tags from remote repositories
+- **Tag Listing with wildcard filtering**
 - **Backup Creation**: Automatic ZIP backup creation before destructive operations
 - **Modern Terminal UI**: Built with [Spectre.Console](https://spectreconsole.net/) for beautiful interfaces
 - **Modern CLI Parsing**: Uses [System.CommandLine](https://github.com/dotnet/command-line-api) for extensible command-line parsing
 
 ## Commands
 
-GitTools provides two main commands for repository management:
+GitTools provides three main commands for repository management:
 
 ### Remove Tags (rm)
 
@@ -83,6 +85,20 @@ GitTools rm C:/Projects "NET8,v1.*,beta-?"
 - `tags` (required): Comma-separated list of tags or wildcard patterns to search and remove (e.g., `NET8,NET7` or `v1.*,beta-?`)
 - `--remote`, `-r`, `/remote` (optional): Also remove the tag from the remote repository (origin)
 - `--help` or `-h`: Show help and usage information
+
+### List Tags (ls)
+
+List repositories containing specific tags. Supports the same wildcard patterns as tag removal.
+
+```sh
+GitTools ls <root-directory> <tag1,tag2,...>
+```
+
+Example output:
+
+```
+Repo1: v1.0, v2.0
+```
 
 ### Reclone Repository (reclone)
 


### PR DESCRIPTION
## Summary
- implement `TagListCommand` for listing repos with tags
- register new command
- test tag listing and registration behavior
- document the new `ls` command in README

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685063622e688325bcd930b6bed77236