### PR TITLE
Add SSH option for bulk restore

### DIFF
--- a/GitTools.Tests/Commands/BulkRestoreCommandTests.cs
+++ b/GitTools.Tests/Commands/BulkRestoreCommandTests.cs
@@ -35,7 +35,8 @@ public sealed class BulkRestoreCommandTests
     [Fact]
     public void Constructor_ShouldConfigureOptions()
     {
-        _command.Options.ShouldContain(o => o.Name == "force-ssh" && o.Description == "Convert repository URLs to SSH");
+        _command.Options.Count.ShouldBe(1);
+        _command.Options.ShouldContain(o => o.Name == "force-ssh" && o.Description == "Force SSH URLs for cloning repositories");
     }
 
     [Fact]

--- a/GitTools.Tests/Commands/TagRemoveCommandTests.cs
+++ b/GitTools.Tests/Commands/TagRemoveCommandTests.cs
@@ -361,6 +361,22 @@ public sealed class TagRemoveCommandTests
             []
         );
 
+        _mockTagSearchService.WhenForAnyArgs
+        (
+            substituteCall => substituteCall.SearchRepositoriesWithTagsAsync(
+                Arg.Any<string>(),
+                Arg.Any<string[]>(),
+                Arg.Any<Action<string>?>())
+        )
+        .Do
+        (
+            callInfo =>
+            {
+                var action = callInfo.Arg<Action<string>?>(); // Capture the action to simulate progress updates
+                action?.Invoke("Searching repositories...");
+            }
+        );
+
         _mockTagValidationService.ParseAndValidateTags(TAGS_INPUT).Returns(tags);
         _mockTagSearchService.SearchRepositoriesWithTagsAsync(@"C:\TestRepo", tags, Arg.Any<Action<string>?>()).Returns(searchResult);
         _mockConsoleDisplayService.GetHierarchicalName(REPO1_PATH, @"C:\TestRepo").Returns("Repo1");


### PR DESCRIPTION
## Summary
- allow forcing ssh URLs with `--force-ssh` when restoring repos
- pass new option through the restore flow
- convert https URLs to ssh style before cloning
- test the option behaviour

## Testing
- `dotnet test` *(fails: Shouldly.ShouldAssertException : result ...)*

------
https://chatgpt.com/codex/tasks/task_e_6856e010769883259a3a5144dd6dc3b1