### PR TITLE
Add force-ssh example for restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,12 @@ Clone repositories from a configuration file created by the bulk backup command.
 GitTools restore repos.json <target-directory>
 ```
 
+Use `--force-ssh` to convert all repository URLs in the JSON file to SSH before cloning.
+
+```sh
+GitTools restore repos.json <target-directory> --force-ssh
+```
+
 
 ## Build
 


### PR DESCRIPTION
## Summary
- document `--force-ssh` option in the Bulk Restore section

## Testing
- `dotnet test --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6856e9052fcc8325aa9e88ea2db54a57