### PR TITLE
Add Serilog logging option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,8 @@ This Agents.md file provides comprehensive guidance for AI agents working with t
 
 For Linux environments (like Codex), use the setup script to install .NET SDK and required tools:
 
+Do not run as root.
+
 ```bash
 # Make the setup script executable
 chmod +x setup-environment.sh

--- a/GitTools.Tests/Services/AnsiConsoleWrapperTests.cs
+++ b/GitTools.Tests/Services/AnsiConsoleWrapperTests.cs
@@ -2,6 +2,7 @@ using Spectre.Console;
 using Spectre.Console.Rendering;
 using GitTools.Services;
 using Spectre.Console.Testing;
+using Serilog;
 
 namespace GitTools.Tests.Services;
 
@@ -15,11 +16,13 @@ public sealed class AnsiConsoleWrapperTests
     private const bool DISABLED = false;
 
     private readonly IAnsiConsole _mockConsole = Substitute.For<IAnsiConsole>();
+    private readonly ILogger _logger = Substitute.For<ILogger>();
     private readonly AnsiConsoleWrapper _wrapper;
 
     public AnsiConsoleWrapperTests()
     {
         _wrapper = new AnsiConsoleWrapper(_mockConsole);
+        _wrapper.SetLogger(_logger);
     }
 
     [Fact]
@@ -60,6 +63,20 @@ public sealed class AnsiConsoleWrapperTests
 
         // Assert
         _mockConsole.Received(1).Write(renderable);
+    }
+
+    [Fact]
+    public void Write_WhenLoggerConfigured_WritesToLogger()
+    {
+        // Arrange
+        _wrapper.Enabled = ENABLED;
+        var renderable = new Markup("test");
+
+        // Act
+        _wrapper.Write(renderable);
+
+        // Assert
+        _logger.Received(1).Information(renderable.ToString());
     }
 
     [Fact]

--- a/GitTools.Tests/Services/AnsiConsoleWrapperTests.cs
+++ b/GitTools.Tests/Services/AnsiConsoleWrapperTests.cs
@@ -69,14 +69,17 @@ public sealed class AnsiConsoleWrapperTests
     public void Write_WhenLoggerConfigured_WritesToLogger()
     {
         // Arrange
-        _wrapper.Enabled = ENABLED;
-        var renderable = new Markup("test");
+        AnsiConsoleWrapper wrapper = new(new TestConsole());
+        wrapper.SetLogger(_logger);
+        wrapper.Enabled = ENABLED;
+        const string MSG = "test";
+        var renderable = new Paragraph(MSG);
 
         // Act
-        _wrapper.Write(renderable);
+        wrapper.Write(renderable);
 
         // Assert
-        _logger.Received(1).Information(renderable.ToString());
+        _logger.Received(1).Information("{@Msg}", MSG);
     }
 
     [Fact]

--- a/GitTools.Tests/StartupTests.cs
+++ b/GitTools.Tests/StartupTests.cs
@@ -172,6 +172,28 @@ public sealed class StartupTests
     }
 
     [Fact]
+    public void BuildCommand_WithLogFile_ShouldConfigureLogger()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        services.RegisterServices();
+        var serviceProvider = services.BuildServiceProvider();
+
+        // Act
+        var (_, rootCommand, invocationMiddleware) = serviceProvider.BuildCommand();
+        var parseResult = rootCommand.Parse("--log-file log.txt");
+        invocationMiddleware.Invoke(new InvocationContext(parseResult), static _ => Task.CompletedTask);
+
+        // Assert
+        var console = serviceProvider.GetService<AnsiConsoleWrapper>();
+        console.ShouldNotBeNull();
+        console.IsLogging.ShouldBeTrue();
+        var gitToolsOptions = serviceProvider.GetService<GitToolsOptions>();
+        gitToolsOptions.ShouldNotBeNull();
+        gitToolsOptions.LogFilePath.ShouldBe("log.txt");
+    }
+
+    [Fact]
     public void BuildCommand_ShouldAddTagRemoveCommand()
     {
         // Arrange

--- a/GitTools.Tests/StartupTests.cs
+++ b/GitTools.Tests/StartupTests.cs
@@ -151,6 +151,7 @@ public sealed class StartupTests
         rootCommand.ShouldNotBeNull();
         rootCommand.Description.ShouldBe("GitTools - A tool for managing your Git repositories.");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "log-all-git-commands");
+        rootCommand.Options.ShouldContain(static opt => opt.Name == "log-file");
     }
 
     [Fact]
@@ -481,6 +482,7 @@ public sealed class StartupTests
 
         // Assert
         rootCommand.Options.ShouldContain(static opt => opt.Name == "log-all-git-commands");
+        rootCommand.Options.ShouldContain(static opt => opt.Name == "log-file");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "disable-ansi");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "quiet");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "help");

--- a/GitTools/GitTools.csproj
+++ b/GitTools/GitTools.csproj
@@ -17,6 +17,8 @@
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.IO.Abstractions" Version="22.0.14" />
+    <PackageReference Include="Serilog" Version="3.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/GitTools/Models/GitToolsOptions.cs
+++ b/GitTools/Models/GitToolsOptions.cs
@@ -12,4 +12,9 @@ public sealed class GitToolsOptions
     /// Gets or sets a value indicating whether all git commands should be logged to the console.
     /// </summary>
     public bool LogAllGitCommands { get; set; }
+
+    /// <summary>
+    /// Gets or sets the path to the log file where console output will be replicated.
+    /// </summary>
+    public string? LogFilePath { get; set; }
 }

--- a/GitTools/Properties/launchSettings.json
+++ b/GitTools/Properties/launchSettings.json
@@ -18,7 +18,7 @@
     },
     "Sync show": {
       "commandName": "Project",
-      "commandLineArgs": "sync d:\\projetos --show-only --no-fetch -lg"
+      "commandLineArgs": "sync d:\\projetos --show-only --no-fetch -lg -lf d:\\sync.log"
     },
     "Help": {
       "commandName": "Project",

--- a/GitTools/Services/AnsiConsoleWrapper.cs
+++ b/GitTools/Services/AnsiConsoleWrapper.cs
@@ -1,4 +1,5 @@
-﻿using Spectre.Console;
+﻿using Serilog;
+using Spectre.Console;
 using Spectre.Console.Rendering;
 
 namespace GitTools.Services;
@@ -14,7 +15,12 @@ namespace GitTools.Services;
 /// </param>
 public sealed class AnsiConsoleWrapper(IAnsiConsole ansiConsole) : IAnsiConsole
 {
+    private ILogger? _logger;
+
     public bool Enabled { get; set; }
+
+    public void SetLogger(ILogger logger)
+        => _logger = logger;
 
     /// <inheritdoc />
     public void Clear(bool home)
@@ -32,6 +38,7 @@ public sealed class AnsiConsoleWrapper(IAnsiConsole ansiConsole) : IAnsiConsole
             return;
 
         ansiConsole.Write(renderable);
+        _logger?.Information(renderable.ToString());
     }
 
     /// <inheritdoc />

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -104,13 +104,14 @@ public static class Startup
             console.Profile.Capabilities.Ansi = !disableAnsi;
             console.Enabled = !quiet;
 
-            if (!string.IsNullOrWhiteSpace(gitToolsOptions.LogFilePath))
-            {
-                var logger = new LoggerConfiguration()
-                    .WriteTo.File(gitToolsOptions.LogFilePath)
-                    .CreateLogger();
-                console.SetLogger(logger);
-            }
+            if (string.IsNullOrWhiteSpace(gitToolsOptions.LogFilePath))
+                return next(context);
+
+            var logger = new LoggerConfiguration()
+                .WriteTo.File(gitToolsOptions.LogFilePath)
+                .CreateLogger();
+
+            console.SetLogger(logger);
 
             return next(context);
         }

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ GitTools provides several commands for repository management, all supporting glo
 These options are available for all commands:
 
 - `--log-all-git-commands`, `-lg`: Log all git commands executed to the console (useful for debugging)
+- `--log-file`, `-lf`: Replicate all console output to the specified log file
 - `--disable-ansi`, `-da`: Disable ANSI color codes in console output (useful for plain text output or incompatible terminals)
 - `--quiet`, `-q`: Suppress all console output (useful for automated scripts or silent operation)
 
@@ -66,6 +67,9 @@ GitTools sync C:/Projects --quiet
 
 # Combine multiple global options
 GitTools reclone ./my-project --log-all-git-commands --disable-ansi
+
+# Write output to a log file
+GitTools ls ./projects --log-file gittools.log
 ```
 
 ### Remove Tags (rm)

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Script to setup development environment for GitTools on Linux systems
 # Installs .NET SDK and required tools for code coverage
+# Do not run as root
 
 set -e  # Exit on any error
 


### PR DESCRIPTION
## Summary
- add `--log-file` global option
- replicate output via Serilog
- update `GitToolsOptions`
- document logging option in README
- test new flag and console wrapper logging

## Testing
- `dotnet build`
- `dotnet test` *(fails: RunGitCommandAsync expectation errors)*
- `dotnet publish GitTools/GitTools.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685aace8e9948325be7ba830f51e1dc5