### PR TITLE
Add no-submodules option

### DIFF
--- a/GitTools.Tests/Commands/SynchronizeCommandTests.cs
+++ b/GitTools.Tests/Commands/SynchronizeCommandTests.cs
@@ -38,7 +38,7 @@ public sealed class SynchronizeCommandTests
     public void Constructor_ShouldConfigureArgumentsAndOptions()
     {
         _command.Arguments.Count.ShouldBe(1);
-        _command.Options.Count.ShouldBe(5);
+        _command.Options.Count.ShouldBe(6);
 
         var rootArg = _command.Arguments[0];
         rootArg.Name.ShouldBe("root-directory");
@@ -49,7 +49,7 @@ public sealed class SynchronizeCommandTests
     public async Task ExecuteAsync_NoRepositories_ShouldShowMessage()
     {
         // Arrange
-        _mockScanner.Scan(_rootDirectory).Returns([]);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns([]);
 
         // Act
         await _command.InvokeAsync([_rootDirectory]);
@@ -63,7 +63,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
@@ -80,7 +80,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -100,7 +100,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, false)
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -116,11 +116,45 @@ public sealed class SynchronizeCommandTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_WithNoSubmodulesOption_ShouldNotProcessSubmodules()
+    {
+        // Arrange
+        var repoPaths = new List<string> { _repoPath };
+        _mockScanner.Scan(_rootDirectory, false).Returns(repoPaths);
+
+        _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
+            .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
+
+        // Act
+        await _command.InvokeAsync([_rootDirectory, "--no-submodules"]);
+
+        // Assert
+        _mockScanner.Received(1).Scan(_rootDirectory, false);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithoutNoSubmodulesOption_ShouldProcessSubmodules()
+    {
+        // Arrange
+        var repoPaths = new List<string> { _repoPath };
+        _mockScanner.Scan(_rootDirectory, true).Returns(repoPaths);
+
+        _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
+            .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
+
+        // Act
+        await _command.InvokeAsync([_rootDirectory]);
+
+        // Assert
+        _mockScanner.Received(1).Scan(_rootDirectory, true);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Automatic_ShouldUpdateAllOutdatedRepos()
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -150,7 +184,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -191,7 +225,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -223,7 +257,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .ThrowsAsync(new InvalidOperationException("Fail to get repository status"));

--- a/GitTools.Tests/Services/GitRepositoryScannerTests.cs
+++ b/GitTools.Tests/Services/GitRepositoryScannerTests.cs
@@ -140,6 +140,68 @@ public sealed class GitRepositoryScannerTests
     }
 
     [Fact]
+    public void Scan_WithIncludeSubmodulesFalse_ShouldNotIncludeSubmodules()
+    {
+        // Arrange
+        var mainRepoPath = Path.Combine(_rootFolder, "main");
+        var submodulePath = Path.Combine(mainRepoPath, "submodule");
+
+        var mainGitPath = Path.Combine(mainRepoPath, GIT_DIR);
+        var subGitPath = Path.Combine(submodulePath, GIT_DIR);
+        var gitmodulesPath = Path.Combine(mainRepoPath, GIT_MODULES_FILE);
+
+        _fileSystem.AddDirectory(mainGitPath);
+        _fileSystem.AddDirectory(subGitPath);
+
+        const string GITMODULES_CONTENT = """
+            [submodule "submodule"]
+                path = submodule
+                url = https://github.com/user/submodule.git
+            """;
+
+        _fileSystem.AddFile(gitmodulesPath, new MockFileData(GITMODULES_CONTENT));
+
+        // Act
+        var result = _scanner.Scan(_rootFolder, false);
+
+        // Assert
+        result.ShouldContain(mainRepoPath);
+        result.ShouldNotContain(submodulePath);
+        result.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public void Scan_WithIncludeSubmodulesTrue_ShouldIncludeSubmodules()
+    {
+        // Arrange
+        var mainRepoPath = Path.Combine(_rootFolder, "main");
+        var submodulePath = Path.Combine(mainRepoPath, "submodule");
+
+        var mainGitPath = Path.Combine(mainRepoPath, GIT_DIR);
+        var subGitPath = Path.Combine(submodulePath, GIT_DIR);
+        var gitmodulesPath = Path.Combine(mainRepoPath, GIT_MODULES_FILE);
+
+        _fileSystem.AddDirectory(mainGitPath);
+        _fileSystem.AddDirectory(subGitPath);
+
+        const string GITMODULES_CONTENT = """
+            [submodule "submodule"]
+                path = submodule
+                url = https://github.com/user/submodule.git
+            """;
+
+        _fileSystem.AddFile(gitmodulesPath, new MockFileData(GITMODULES_CONTENT));
+
+        // Act
+        var result = _scanner.Scan(_rootFolder, true);
+
+        // Assert
+        result.ShouldContain(mainRepoPath);
+        result.ShouldContain(submodulePath);
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
     public void Scan_WithInvalidSubmodulePath_ShouldIgnoreInvalidSubmodule()
     {
         // Arrange
@@ -335,7 +397,7 @@ public sealed class GitRepositoryScannerTests
         
         processDirectoryMethod!.Invoke(
             scanner,
-            [ALREADY_PROCESSED_DIR, gitRepos, processedPaths, pendingDirs]
+            [ALREADY_PROCESSED_DIR, gitRepos, processedPaths, pendingDirs, true]
         );
         
         // Assert

--- a/GitTools/Commands/SynchronizeCommand.cs
+++ b/GitTools/Commands/SynchronizeCommand.cs
@@ -29,6 +29,7 @@ public sealed class SynchronizeCommand : Command
         var pushUntrackedBranchesOption = new Option<bool>(["--push-untracked", "-pu"], "Push untracked branches to the remote repository");
         var automaticOption = new Option<bool>(["--automatic", "-a"], "Run the command without user interaction (useful for scripts)");
         var noFetchOption = new Option<bool>(["--no-fetch", "-nf"], "Do not fetch from remote before checking repositories");
+        var noSubmodulesOption = new Option<bool>(["--no-submodules", "-ns"], "Do not include submodules during repository scanning");
 
         AddArgument(rootArg);
         AddOption(showOnlyOption);
@@ -36,6 +37,7 @@ public sealed class SynchronizeCommand : Command
         AddOption(pushUntrackedBranchesOption);
         AddOption(automaticOption);
         AddOption(noFetchOption);
+        AddOption(noSubmodulesOption);
 
         this.SetHandler
         (
@@ -45,17 +47,18 @@ public sealed class SynchronizeCommand : Command
             withUncommittedOption,
             pushUntrackedBranchesOption,
             automaticOption,
-            noFetchOption
+            noFetchOption,
+            noSubmodulesOption
         );
     }
 
-    private async Task ExecuteAsync(string rootDirectory, bool showOnly, bool withUncommited, bool pushUntrackedBranches, bool automatic, bool noFetch)
+    private async Task ExecuteAsync(string rootDirectory, bool showOnly, bool withUncommited, bool pushUntrackedBranches, bool automatic, bool noFetch, bool noSubmodules)
     {
         var repoPaths = _console.Status()
             .Start
             (
                 $"[yellow]Scanning for Git repositories in {rootDirectory}...[/]",
-                _ => _scanner.Scan(rootDirectory)
+                _ => _scanner.Scan(rootDirectory, !noSubmodules)
             );
 
         if (repoPaths.Count == 0)

--- a/GitTools/Services/GitRepositoryScanner.cs
+++ b/GitTools/Services/GitRepositoryScanner.cs
@@ -15,9 +15,15 @@ public sealed partial class GitRepositoryScanner(IAnsiConsole console, IFileSyst
     /// <inheritdoc/>
     public List<string> Scan(string rootFolder)
     {
+        return Scan(rootFolder, true);
+    }
+
+    /// <inheritdoc/>
+    public List<string> Scan(string rootFolder, bool includeSubmodules)
+    {
         var gitRepos = new List<string>();
         var processedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        SearchGitRepositories(rootFolder, gitRepos, processedPaths);
+        SearchGitRepositories(rootFolder, gitRepos, processedPaths, includeSubmodules);
 
         return [.. gitRepos.Distinct()];
     }
@@ -38,7 +44,8 @@ public sealed partial class GitRepositoryScanner(IAnsiConsole console, IFileSyst
     (
         string rootFolder,
         List<string> gitRepos,
-        HashSet<string> processedPaths
+        HashSet<string> processedPaths,
+        bool includeSubmodules = true
     )
     {
         var stack = new Stack<string>();
@@ -47,7 +54,7 @@ public sealed partial class GitRepositoryScanner(IAnsiConsole console, IFileSyst
         while (stack.Count > 0)
         {
             var currentDir = stack.Pop();
-            ProcessDirectory(currentDir, gitRepos, processedPaths, stack);
+            ProcessDirectory(currentDir, gitRepos, processedPaths, stack, includeSubmodules);
         }
     }
 
@@ -71,7 +78,8 @@ public sealed partial class GitRepositoryScanner(IAnsiConsole console, IFileSyst
         string currentDir,
         List<string> gitRepos,
         HashSet<string> processedPaths,
-        Stack<string> pendingDirs
+        Stack<string> pendingDirs,
+        bool includeSubmodules
     )
     {
         try
@@ -86,7 +94,10 @@ public sealed partial class GitRepositoryScanner(IAnsiConsole console, IFileSyst
                     gitRepos.Add(currentDir);
                 }
 
-                AddSubmodules(currentDir, processedPaths, pendingDirs);
+                if (includeSubmodules)
+                {
+                    AddSubmodules(currentDir, processedPaths, pendingDirs);
+                }
             }
             else
             {

--- a/GitTools/Services/IGitRepositoryScanner.cs
+++ b/GitTools/Services/IGitRepositoryScanner.cs
@@ -10,4 +10,11 @@ public interface IGitRepositoryScanner
     /// </summary>
     /// <param name="rootFolder">Root directory to scan.</param>
     List<string> Scan(string rootFolder);
+
+    /// <summary>
+    /// Finds Git repositories from the root folder with optional submodule inclusion.
+    /// </summary>
+    /// <param name="rootFolder">Root directory to scan.</param>
+    /// <param name="includeSubmodules">Whether to include submodules in the scan.</param>
+    List<string> Scan(string rootFolder, bool includeSubmodules);
 }


### PR DESCRIPTION
## Summary
- allow ignoring submodules when scanning repositories
- add `--no-submodules` (`-ns`) option to `sync` command
- update unit tests for new scanning option
- cover new CLI behaviour in command tests

## Testing
- `dotnet build GitTools.sln`
- `dotnet test --no-build`
- `./generate-coverage.sh` *(fails: `reportgenerator` not found)*
- `dotnet publish GitTools/GitTools.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685b12de98dc8325aac98114d266a383