### PR TITLE
Add global submodule scanning option

### DIFF
--- a/GitTools.Tests/Commands/SynchronizeCommandTests.cs
+++ b/GitTools.Tests/Commands/SynchronizeCommandTests.cs
@@ -38,7 +38,7 @@ public sealed class SynchronizeCommandTests
     public void Constructor_ShouldConfigureArgumentsAndOptions()
     {
         _command.Arguments.Count.ShouldBe(1);
-        _command.Options.Count.ShouldBe(6);
+        _command.Options.Count.ShouldBe(5);
 
         var rootArg = _command.Arguments[0];
         rootArg.Name.ShouldBe("root-directory");
@@ -49,7 +49,7 @@ public sealed class SynchronizeCommandTests
     public async Task ExecuteAsync_NoRepositories_ShouldShowMessage()
     {
         // Arrange
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns([]);
+        _mockScanner.Scan(_rootDirectory).Returns([]);
 
         // Act
         await _command.InvokeAsync([_rootDirectory]);
@@ -63,7 +63,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
@@ -80,7 +80,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -100,7 +100,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, false)
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -116,28 +116,11 @@ public sealed class SynchronizeCommandTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithNoSubmodulesOption_ShouldNotProcessSubmodules()
+    public async Task ExecuteAsync_ShouldScanRepositories()
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, false).Returns(repoPaths);
-
-        _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
-            .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
-
-        // Act
-        await _command.InvokeAsync([_rootDirectory, "--no-submodules"]);
-
-        // Assert
-        _mockScanner.Received(1).Scan(_rootDirectory, false);
-    }
-
-    [Fact]
-    public async Task ExecuteAsync_WithoutNoSubmodulesOption_ShouldProcessSubmodules()
-    {
-        // Arrange
-        var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, true).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
@@ -146,7 +129,24 @@ public sealed class SynchronizeCommandTests
         await _command.InvokeAsync([_rootDirectory]);
 
         // Assert
-        _mockScanner.Received(1).Scan(_rootDirectory, true);
+        _mockScanner.Received(1).Scan(_rootDirectory);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldProcessSubmodules()
+    {
+        // Arrange
+        var repoPaths = new List<string> { _repoPath };
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
+
+        _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
+            .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _syncedBranches));
+
+        // Act
+        await _command.InvokeAsync([_rootDirectory]);
+
+        // Assert
+        _mockScanner.Received(1).Scan(_rootDirectory);
     }
 
     [Fact]
@@ -154,7 +154,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -184,7 +184,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -225,7 +225,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .Returns(new GitRepositoryStatus(REPO_NAME, REPO_NAME, _repoPath, "https://example.com", false, _outdatedBranches));
@@ -257,7 +257,7 @@ public sealed class SynchronizeCommandTests
     {
         // Arrange
         var repoPaths = new List<string> { _repoPath };
-        _mockScanner.Scan(_rootDirectory, Arg.Any<bool>()).Returns(repoPaths);
+        _mockScanner.Scan(_rootDirectory).Returns(repoPaths);
 
         _mockGitService.GetRepositoryStatusAsync(_repoPath, _rootDirectory, Arg.Any<bool>())
             .ThrowsAsync(new InvalidOperationException("Fail to get repository status"));

--- a/GitTools.Tests/StartupTests.cs
+++ b/GitTools.Tests/StartupTests.cs
@@ -194,6 +194,21 @@ public sealed class StartupTests
     }
 
     [Fact]
+    public void BuildCommand_WithIncludeSubmodulesFalse_ShouldUpdateOptions()
+    {
+        var services = new ServiceCollection();
+        services.RegisterServices();
+        var provider = services.BuildServiceProvider();
+
+        var (_, rootCommand, middleware) = provider.BuildCommand();
+        var parse = rootCommand.Parse("--include-submodules false");
+        middleware.Invoke(new InvocationContext(parse), static _ => Task.CompletedTask);
+
+        var options = provider.GetRequiredService<GitToolsOptions>();
+        options.IncludeSubmodules.ShouldBeFalse();
+    }
+
+    [Fact]
     public void BuildCommand_ShouldAddTagRemoveCommand()
     {
         // Arrange
@@ -507,6 +522,7 @@ public sealed class StartupTests
         rootCommand.Options.ShouldContain(static opt => opt.Name == "log-file");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "disable-ansi");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "quiet");
+        rootCommand.Options.ShouldContain(static opt => opt.Name == "include-submodules");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "help");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "version");
     }

--- a/GitTools/Commands/SynchronizeCommand.cs
+++ b/GitTools/Commands/SynchronizeCommand.cs
@@ -29,7 +29,6 @@ public sealed class SynchronizeCommand : Command
         var pushUntrackedBranchesOption = new Option<bool>(["--push-untracked", "-pu"], "Push untracked branches to the remote repository");
         var automaticOption = new Option<bool>(["--automatic", "-a"], "Run the command without user interaction (useful for scripts)");
         var noFetchOption = new Option<bool>(["--no-fetch", "-nf"], "Do not fetch from remote before checking repositories");
-        var noSubmodulesOption = new Option<bool>(["--no-submodules", "-ns"], "Do not include submodules during repository scanning");
 
         AddArgument(rootArg);
         AddOption(showOnlyOption);
@@ -37,7 +36,6 @@ public sealed class SynchronizeCommand : Command
         AddOption(pushUntrackedBranchesOption);
         AddOption(automaticOption);
         AddOption(noFetchOption);
-        AddOption(noSubmodulesOption);
 
         this.SetHandler
         (
@@ -47,18 +45,17 @@ public sealed class SynchronizeCommand : Command
             withUncommittedOption,
             pushUntrackedBranchesOption,
             automaticOption,
-            noFetchOption,
-            noSubmodulesOption
+            noFetchOption
         );
     }
 
-    private async Task ExecuteAsync(string rootDirectory, bool showOnly, bool withUncommited, bool pushUntrackedBranches, bool automatic, bool noFetch, bool noSubmodules)
+    private async Task ExecuteAsync(string rootDirectory, bool showOnly, bool withUncommited, bool pushUntrackedBranches, bool automatic, bool noFetch)
     {
         var repoPaths = _console.Status()
             .Start
             (
                 $"[yellow]Scanning for Git repositories in {rootDirectory}...[/]",
-                _ => _scanner.Scan(rootDirectory, !noSubmodules)
+                _ => _scanner.Scan(rootDirectory)
             );
 
         if (repoPaths.Count == 0)

--- a/GitTools/Models/GitToolsOptions.cs
+++ b/GitTools/Models/GitToolsOptions.cs
@@ -17,4 +17,9 @@ public sealed class GitToolsOptions
     /// Gets or sets the path to the log file where console output will be replicated.
     /// </summary>
     public string? LogFilePath { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether submodules should be included when scanning for repositories.
+    /// </summary>
+    public bool IncludeSubmodules { get; set; } = true;
 }

--- a/GitTools/Services/GitRepositoryScanner.cs
+++ b/GitTools/Services/GitRepositoryScanner.cs
@@ -1,5 +1,6 @@
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
+using GitTools.Models;
 using Spectre.Console;
 
 namespace GitTools.Services;
@@ -7,23 +8,23 @@ namespace GitTools.Services;
 /// <summary>
 /// Scans directories for git repositories and submodules.
 /// </summary>
-public sealed partial class GitRepositoryScanner(IAnsiConsole console, IFileSystem fileSystem) : IGitRepositoryScanner
+public sealed partial class GitRepositoryScanner
+(
+    IAnsiConsole console,
+    IFileSystem fileSystem,
+    GitToolsOptions options
+) : IGitRepositoryScanner
 {
     private const string GIT_DIR = ".git";
     private const string GIT_MODULES_FILE = ".gitmodules";
+    private readonly GitToolsOptions _options = options;
 
     /// <inheritdoc/>
     public List<string> Scan(string rootFolder)
     {
-        return Scan(rootFolder, true);
-    }
-
-    /// <inheritdoc/>
-    public List<string> Scan(string rootFolder, bool includeSubmodules)
-    {
         var gitRepos = new List<string>();
         var processedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        SearchGitRepositories(rootFolder, gitRepos, processedPaths, includeSubmodules);
+        SearchGitRepositories(rootFolder, gitRepos, processedPaths, _options.IncludeSubmodules);
 
         return [.. gitRepos.Distinct()];
     }

--- a/GitTools/Services/GitRepositoryScanner.cs
+++ b/GitTools/Services/GitRepositoryScanner.cs
@@ -17,14 +17,13 @@ public sealed partial class GitRepositoryScanner
 {
     private const string GIT_DIR = ".git";
     private const string GIT_MODULES_FILE = ".gitmodules";
-    private readonly GitToolsOptions _options = options;
 
     /// <inheritdoc/>
     public List<string> Scan(string rootFolder)
     {
         var gitRepos = new List<string>();
         var processedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-        SearchGitRepositories(rootFolder, gitRepos, processedPaths, _options.IncludeSubmodules);
+        SearchGitRepositories(rootFolder, gitRepos, processedPaths, options.IncludeSubmodules);
 
         return [.. gitRepos.Distinct()];
     }
@@ -102,9 +101,7 @@ public sealed partial class GitRepositoryScanner
                 }
 
                 if (includeSubmodules)
-                {
                     AddSubmodules(currentDir, processedPaths, pendingDirs);
-                }
             }
             else
             {

--- a/GitTools/Services/IGitRepositoryScanner.cs
+++ b/GitTools/Services/IGitRepositoryScanner.cs
@@ -6,15 +6,9 @@ namespace GitTools.Services;
 public interface IGitRepositoryScanner
 {
     /// <summary>
-    /// Finds all Git repositories and submodules from the root folder.
+    /// Finds all Git repositories from the root folder.
+    /// Submodule inclusion is controlled by the global option.
     /// </summary>
     /// <param name="rootFolder">Root directory to scan.</param>
     List<string> Scan(string rootFolder);
-
-    /// <summary>
-    /// Finds Git repositories from the root folder with optional submodule inclusion.
-    /// </summary>
-    /// <param name="rootFolder">Root directory to scan.</param>
-    /// <param name="includeSubmodules">Whether to include submodules in the scan.</param>
-    List<string> Scan(string rootFolder, bool includeSubmodules);
 }

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -67,10 +67,12 @@ public static class Startup
         var logFileOption = new Option<string?>(["--log-file", "-lf"], "Path to a log file where console output will be replicated");
         var disableAnsiOption = new Option<bool>(["--disable-ansi", "-da"], "Disable ANSI color codes in the console output");
         var quietOption = new Option<bool>(["--quiet", "-q"], "Suppress all console output");
+        var includeSubmodulesOption = new Option<bool>(["--include-submodules", "-is"], () => true, "Include Git submodules when scanning for repositories");
         rootCommand.AddGlobalOption(logAllGitCommandsOption);
         rootCommand.AddGlobalOption(logFileOption);
         rootCommand.AddGlobalOption(disableAnsiOption);
         rootCommand.AddGlobalOption(quietOption);
+        rootCommand.AddGlobalOption(includeSubmodulesOption);
         var tagRemoveCommand = serviceProvider.GetRequiredService<TagRemoveCommand>();
         var tagListCommand = serviceProvider.GetRequiredService<TagListCommand>();
         var recloneCommand = serviceProvider.GetRequiredService<ReCloneCommand>();
@@ -101,6 +103,7 @@ public static class Startup
             gitToolsOptions.LogFilePath = context.ParseResult.GetValueForOption(logFileOption);
             var disableAnsi = context.ParseResult.GetValueForOption(disableAnsiOption);
             var quiet = context.ParseResult.GetValueForOption(quietOption);
+            gitToolsOptions.IncludeSubmodules = context.ParseResult.GetValueForOption(includeSubmodulesOption);
             console.Profile.Capabilities.Ansi = !disableAnsi;
             console.Enabled = !quiet;
 

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -101,9 +101,9 @@ public static class Startup
         {
             gitToolsOptions.LogAllGitCommands = context.ParseResult.GetValueForOption(logAllGitCommandsOption);
             gitToolsOptions.LogFilePath = context.ParseResult.GetValueForOption(logFileOption);
+            gitToolsOptions.IncludeSubmodules = context.ParseResult.GetValueForOption(includeSubmodulesOption);
             var disableAnsi = context.ParseResult.GetValueForOption(disableAnsiOption);
             var quiet = context.ParseResult.GetValueForOption(quietOption);
-            gitToolsOptions.IncludeSubmodules = context.ParseResult.GetValueForOption(includeSubmodulesOption);
             console.Profile.Capabilities.Ansi = !disableAnsi;
             console.Enabled = !quiet;
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ These options are available for all commands:
 - `--log-file`, `-lf`: Replicate all console output to the specified log file
 - `--disable-ansi`, `-da`: Disable ANSI color codes in console output (useful for plain text output or incompatible terminals)
 - `--quiet`, `-q`: Suppress all console output (useful for automated scripts or silent operation)
+- `--include-submodules`, `-is`: Include Git submodules when scanning for repositories (default true)
 
 **Examples:**
 
@@ -70,6 +71,9 @@ GitTools reclone ./my-project --log-all-git-commands --disable-ansi
 
 # Write output to a log file
 GitTools ls ./projects --log-file gittools.log
+
+# Exclude submodules from scanning
+GitTools sync ./projects --include-submodules false
 ```
 
 ### Remove Tags (rm)
@@ -218,7 +222,7 @@ GitTools restore repos.json <target-directory> --force-ssh
 Detect repositories that are behind the specified branch and optionally update them.
 
 ```sh
-GitTools sync <root-directory> [--show-only] [--with-uncommitted] [--push-untracked] [--automatic] [--no-fetch] [--no-submodules]
+GitTools sync <root-directory> [--show-only] [--with-uncommitted] [--push-untracked] [--automatic] [--no-fetch]
 ```
 
 #### Sync Options
@@ -229,7 +233,6 @@ GitTools sync <root-directory> [--show-only] [--with-uncommitted] [--push-untrac
 - `--push-untracked`, `-pu`: Push untracked branches to the remote repository
 - `--automatic`, `-a`: Run the command without user interaction (useful for scripts)
 - `--no-fetch`, `-nf`: Do not fetch from remote before checking repositories
-- `--no-submodules`, `-ns`: Do not include submodules during repository scanning
 
 #### Behavior
 
@@ -243,7 +246,7 @@ Use `--automatic` to run without user interaction, automatically selecting all o
 
 Use `--push-untracked` to also push any new local branches to the remote repository during synchronization.
 
-Use `--no-submodules` to exclude Git submodules from the scanning process.
+Use `--include-submodules false` to exclude Git submodules from the scanning process.
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -307,6 +307,9 @@ This project uses the following open source libraries:
 
 - [Spectre.Console](https://spectreconsole.net/) — for beautiful, interactive console UIs in .NET
 - [System.CommandLine](https://github.com/dotnet/command-line-api) — for modern, extensible command-line parsing
+- [Serilog](https://serilog.net/) - for logging capabilities
+- [Shouldly](https://github.com/shouldly/shouldly) - for elegant - and free - unit test assertions
+- [NSubstitute](https://nsubstitute.github.io/) - for simple and effective mocking
 
 ## License
 


### PR DESCRIPTION
## Summary
- add `IncludeSubmodules` to `GitToolsOptions`
- remove local submodule option from `SynchronizeCommand`
- move include-submodules flag to `Startup` as a global option
- simplify `IGitRepositoryScanner` API
- update repository scanner implementation
- adjust docs and unit tests

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet publish GitTools/GitTools.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685be7ac59d48325bca05090d8e8c45d