### PR TITLE
Add repository filter option

### DIFF
--- a/GitTools.Tests/Services/GitRepositoryScannerTests.cs
+++ b/GitTools.Tests/Services/GitRepositoryScannerTests.cs
@@ -64,6 +64,47 @@ public sealed class GitRepositoryScannerTests
     }
 
     [Fact]
+    public void Scan_WithRepositoryFilters_ShouldFilterRepositories()
+    {
+        // Arrange
+        _options.RepositoryFilters = ["frontend-*", "*-service"];
+        var frontend = Path.Combine(_rootFolder, "frontend-app");
+        var backend = Path.Combine(_rootFolder, "backend-api");
+        var service = Path.Combine(_rootFolder, "user-service");
+        var tools = Path.Combine(_rootFolder, "tools");
+
+        _fileSystem.AddDirectory(Path.Combine(frontend, GIT_DIR));
+        _fileSystem.AddDirectory(Path.Combine(backend, GIT_DIR));
+        _fileSystem.AddDirectory(Path.Combine(service, GIT_DIR));
+        _fileSystem.AddDirectory(Path.Combine(tools, GIT_DIR));
+
+        // Act
+        var result = _scanner.Scan(_rootFolder);
+
+        // Assert
+        result.ShouldContain(frontend);
+        result.ShouldContain(service);
+        result.ShouldNotContain(backend);
+        result.ShouldNotContain(tools);
+        result.Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public void Scan_WithNonMatchingFilter_ShouldReturnEmptyList()
+    {
+        // Arrange
+        _options.RepositoryFilters = ["does-not-match*"];
+        var repo = Path.Combine(_rootFolder, "repo");
+        _fileSystem.AddDirectory(Path.Combine(repo, GIT_DIR));
+
+        // Act
+        var result = _scanner.Scan(_rootFolder);
+
+        // Assert
+        result.ShouldBeEmpty();
+    }
+
+    [Fact]
     public void Scan_WithNestedGitRepositories_ShouldReturnParentRepository()
     {
         // Arrange

--- a/GitTools.Tests/StartupTests.cs
+++ b/GitTools.Tests/StartupTests.cs
@@ -209,6 +209,21 @@ public sealed class StartupTests
     }
 
     [Fact]
+    public void BuildCommand_WithRepositoryFilter_ShouldUpdateOptions()
+    {
+        var services = new ServiceCollection();
+        services.RegisterServices();
+        var provider = services.BuildServiceProvider();
+
+        var (_, rootCommand, middleware) = provider.BuildCommand();
+        var parse = rootCommand.Parse("--repository-filter *-api --repository-filter frontend-*");
+        middleware.Invoke(new InvocationContext(parse), static _ => Task.CompletedTask);
+
+        var options = provider.GetRequiredService<GitToolsOptions>();
+        options.RepositoryFilters.ShouldBe(["*-api", "frontend-*"]);
+    }
+
+    [Fact]
     public void BuildCommand_ShouldAddTagRemoveCommand()
     {
         // Arrange
@@ -523,6 +538,7 @@ public sealed class StartupTests
         rootCommand.Options.ShouldContain(static opt => opt.Name == "disable-ansi");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "quiet");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "include-submodules");
+        rootCommand.Options.ShouldContain(static opt => opt.Name == "repository-filter");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "help");
         rootCommand.Options.ShouldContain(static opt => opt.Name == "version");
     }

--- a/GitTools/Models/GitToolsOptions.cs
+++ b/GitTools/Models/GitToolsOptions.cs
@@ -22,4 +22,15 @@ public sealed class GitToolsOptions
     /// Gets or sets a value indicating whether submodules should be included when scanning for repositories.
     /// </summary>
     public bool IncludeSubmodules { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the repository filtering patterns using wildcard syntax (* and ?).
+    /// When specified, only repositories matching at least one pattern will be processed.
+    /// </summary>
+    public string[] RepositoryFilters { get; set; } = [];
+
+    /// <summary>
+    /// Gets a value indicating whether repository filtering is enabled.
+    /// </summary>
+    public bool HasRepositoryFilters => RepositoryFilters.Length > 0;
 }

--- a/GitTools/Services/GitRepositoryScanner.cs
+++ b/GitTools/Services/GitRepositoryScanner.cs
@@ -1,6 +1,7 @@
 using System.IO.Abstractions;
 using System.Text.RegularExpressions;
 using GitTools.Models;
+using GitTools.Utils;
 using Spectre.Console;
 
 namespace GitTools.Services;
@@ -25,7 +26,12 @@ public sealed partial class GitRepositoryScanner
         var processedPaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         SearchGitRepositories(rootFolder, gitRepos, processedPaths, options.IncludeSubmodules);
 
-        return [.. gitRepos.Distinct()];
+        var repositories = gitRepos.Distinct().ToList();
+
+        if (options.HasRepositoryFilters)
+            repositories = ApplyRepositoryFiltering(repositories, rootFolder);
+
+        return repositories;
     }
 
     /// <summary>
@@ -168,6 +174,56 @@ public sealed partial class GitRepositoryScanner
         catch (Exception ex)
         {
             console.MarkupLineInterpolated($"[grey]Error processing submodules in: {repoDir} ({ex.Message})[/]");
+        }
+    }
+
+    /// <summary>
+    /// Applies repository filtering based on the configured patterns.
+    /// </summary>
+    /// <param name="repositories">The list of repository paths to filter.</param>
+    /// <param name="rootFolder">The root folder used for relative path calculation.</param>
+    /// <returns>The filtered list of repositories.</returns>
+    private List<string> ApplyRepositoryFiltering(List<string> repositories, string rootFolder)
+    {
+        var filteredRepositories = new List<string>();
+
+        foreach (var filter in options.RepositoryFilters)
+        {
+            var repositoryNames = repositories.Select(path => GetRepositoryName(path, rootFolder));
+            var matchedNames = WildcardMatcher.MatchItems(repositoryNames, filter);
+
+            var matchedPaths = repositories.Where(path => matchedNames.Contains(GetRepositoryName(path, rootFolder)));
+
+            filteredRepositories.AddRange(matchedPaths);
+        }
+
+        var result = filteredRepositories.Distinct().ToList();
+
+        if (result.Count != repositories.Count)
+        {
+            console.MarkupLineInterpolated($"[blue]Repository filtering applied: {result.Count} of {repositories.Count} repositories match the specified patterns.[/]");
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the repository name for filtering purposes.
+    /// </summary>
+    /// <param name="repositoryPath">The full path to the repository.</param>
+    /// <param name="rootFolder">The root folder used for relative path calculation.</param>
+    /// <returns>The repository name used for filtering.</returns>
+    private static string GetRepositoryName(string repositoryPath, string rootFolder)
+    {
+        try
+        {
+            var relativePath = Path.GetRelativePath(rootFolder, repositoryPath);
+
+            return relativePath.Replace('\\', '/');
+        }
+        catch
+        {
+            return Path.GetFileName(repositoryPath) ?? repositoryPath;
         }
     }
 

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -68,11 +68,16 @@ public static class Startup
         var disableAnsiOption = new Option<bool>(["--disable-ansi", "-da"], "Disable ANSI color codes in the console output");
         var quietOption = new Option<bool>(["--quiet", "-q"], "Suppress all console output");
         var includeSubmodulesOption = new Option<bool>(["--include-submodules", "-is"], () => true, "Include Git submodules when scanning for repositories");
+        var repositoryFilterOption = new Option<string[]>(["--repository-filter", "-rf"], "Filter repositories by name using wildcard patterns (*, ?). Can be specified multiple times.")
+        {
+            AllowMultipleArgumentsPerToken = true
+        };
         rootCommand.AddGlobalOption(logAllGitCommandsOption);
         rootCommand.AddGlobalOption(logFileOption);
         rootCommand.AddGlobalOption(disableAnsiOption);
         rootCommand.AddGlobalOption(quietOption);
         rootCommand.AddGlobalOption(includeSubmodulesOption);
+        rootCommand.AddGlobalOption(repositoryFilterOption);
         var tagRemoveCommand = serviceProvider.GetRequiredService<TagRemoveCommand>();
         var tagListCommand = serviceProvider.GetRequiredService<TagListCommand>();
         var recloneCommand = serviceProvider.GetRequiredService<ReCloneCommand>();
@@ -102,6 +107,7 @@ public static class Startup
             gitToolsOptions.LogAllGitCommands = context.ParseResult.GetValueForOption(logAllGitCommandsOption);
             gitToolsOptions.LogFilePath = context.ParseResult.GetValueForOption(logFileOption);
             gitToolsOptions.IncludeSubmodules = context.ParseResult.GetValueForOption(includeSubmodulesOption);
+            gitToolsOptions.RepositoryFilters = context.ParseResult.GetValueForOption(repositoryFilterOption) ?? [];
             var disableAnsi = context.ParseResult.GetValueForOption(disableAnsiOption);
             var quiet = context.ParseResult.GetValueForOption(quietOption);
             console.Profile.Capabilities.Ansi = !disableAnsi;

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ These options are available for all commands:
 - `--disable-ansi`, `-da`: Disable ANSI color codes in console output (useful for plain text output or incompatible terminals)
 - `--quiet`, `-q`: Suppress all console output (useful for automated scripts or silent operation)
 - `--include-submodules`, `-is`: Include Git submodules when scanning for repositories (default true)
+- `--repository-filter`, `-rf`: Filter repositories by name using wildcard patterns. Can be used multiple times.
 
 **Examples:**
 
@@ -74,6 +75,9 @@ GitTools ls ./projects --log-file gittools.log
 
 # Exclude submodules from scanning
 GitTools sync ./projects --include-submodules false
+
+# Filter repositories by name
+GitTools sync ./projects --repository-filter "frontend-*" --repository-filter "*-service"
 ```
 
 ### Remove Tags (rm)


### PR DESCRIPTION
## Summary
- allow wildcard repo filtering via new GitToolsOptions.RepositoryFilters
- apply filtering in GitRepositoryScanner
- expose --repository-filter global option in Startup
- document global filtering
- test new filtering capabilities

## Testing
- `dotnet build`
- `dotnet test`
- `./generate-coverage.sh`
- `dotnet publish GitTools/GitTools.csproj -c Release`

------
https://chatgpt.com/codex/tasks/task_e_685bf067d658832598bb315032822ac0