### PR TITLE
Implement prune-branches command

### DIFF
--- a/GitTools.Tests/Commands/PruneBranchesCommandTests.cs
+++ b/GitTools.Tests/Commands/PruneBranchesCommandTests.cs
@@ -1,0 +1,59 @@
+using System.CommandLine;
+using GitTools.Commands;
+using GitTools.Services;
+using Spectre.Console.Testing;
+using Shouldly;
+using NSubstitute;
+
+namespace GitTools.Tests.Commands;
+
+[ExcludeFromCodeCoverage]
+public sealed class PruneBranchesCommandTests
+{
+    private readonly IGitRepositoryScanner _scanner = Substitute.For<IGitRepositoryScanner>();
+    private readonly IGitService _gitService = Substitute.For<IGitService>();
+    private readonly IConsoleDisplayService _display = Substitute.For<IConsoleDisplayService>();
+    private readonly TestConsole _console = new();
+    private readonly PruneBranchesCommand _command;
+
+    public PruneBranchesCommandTests()
+    {
+        _console.Interactive();
+        _command = new PruneBranchesCommand(_scanner, _gitService, _console, _display);
+    }
+
+    [Fact]
+    public void Constructor_ShouldSetNameAndDescription()
+    {
+        _command.Name.ShouldBe("prune-branches");
+        _command.Description.ShouldBe("Prunes local branches in git repositories.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoRepositories_ShouldShowMessage()
+    {
+        // Arrange
+        _scanner.Scan("C:/repos").Returns([]);
+
+        // Act
+        await _command.Parse(["C:/repos"]).InvokeAsync();
+
+        // Assert
+        _console.Output.ShouldContain("No Git repositories found.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DryRun_ShouldNotDeleteBranches()
+    {
+        // Arrange
+        _scanner.Scan("C:/repos").Returns(["C:/repos/repo1"]);
+        _gitService.GetPrunableBranchesAsync("C:/repos/repo1", true, false, null).Returns(["feature"]);
+        _display.GetHierarchicalName("C:/repos/repo1", "C:/repos").Returns("repo1");
+
+        // Act
+        await _command.Parse(["C:/repos", "--dry-run"]).InvokeAsync();
+
+        // Assert
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+}

--- a/GitTools.Tests/Commands/PruneBranchesCommandTests.cs
+++ b/GitTools.Tests/Commands/PruneBranchesCommandTests.cs
@@ -1,15 +1,19 @@
-using System.CommandLine;
 using GitTools.Commands;
 using GitTools.Services;
 using Spectre.Console.Testing;
-using Shouldly;
-using NSubstitute;
 
 namespace GitTools.Tests.Commands;
 
 [ExcludeFromCodeCoverage]
 public sealed class PruneBranchesCommandTests
 {
+    private const string ROOT_DIR = @"C:\repos";
+    private const string REPO1_PATH = @"C:\repos\repo1";
+    private const string REPO2_PATH = @"C:\repos\repo2";
+    private const string BRANCH_NAME = "feature/test-branch";
+    private const string MERGED_BRANCH = "feature/merged";
+    private const string GONE_BRANCH = "feature/gone";
+
     private readonly IGitRepositoryScanner _scanner = Substitute.For<IGitRepositoryScanner>();
     private readonly IGitService _gitService = Substitute.For<IGitService>();
     private readonly IConsoleDisplayService _display = Substitute.For<IConsoleDisplayService>();
@@ -25,35 +29,539 @@ public sealed class PruneBranchesCommandTests
     [Fact]
     public void Constructor_ShouldSetNameAndDescription()
     {
+        // Assert
         _command.Name.ShouldBe("prune-branches");
         _command.Description.ShouldBe("Prunes local branches in git repositories.");
+        _command.Aliases.ShouldContain("pb");
     }
 
     [Fact]
-    public async Task ExecuteAsync_NoRepositories_ShouldShowMessage()
+    public void Constructor_ShouldHaveRequiredArguments()
+    {
+        // Assert
+        _command.Arguments.ShouldContain(arg => arg.Name == "root-directory");
+        _command.Options.ShouldContain(opt => opt.Name == "--merged");
+        _command.Options.ShouldContain(opt => opt.Name == "--gone");
+        _command.Options.ShouldContain(opt => opt.Name == "--older-than");
+        _command.Options.ShouldContain(opt => opt.Name == "--automatic");
+        _command.Options.ShouldContain(opt => opt.Name == "--dry-run");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoRepositoriesFound_ShouldShowMessage()
     {
         // Arrange
-        _scanner.Scan("C:/repos").Returns([]);
+        _scanner.Scan(ROOT_DIR).Returns([]);
 
         // Act
-        await _command.Parse(["C:/repos"]).InvokeAsync();
+        await _command.Parse([ROOT_DIR]).InvokeAsync();
 
         // Assert
+        _console.Output.ShouldContain("No Git repositories found.");
+        await _gitService.DidNotReceive().GetPrunableBranchesAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<int?>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoBranchesToPrune_ShouldShowMessage()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([]);
+
+        // Act
+        await _command.Parse([ROOT_DIR]).InvokeAsync();
+
+        // Assert
+        _console.Output.ShouldContain("No branches to prune found.");
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithDryRun_ShouldNotDeleteBranches()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([BRANCH_NAME]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--dry-run", "--automatic"]).InvokeAsync();
+
+        // Assert
+        _console.Output.ShouldContain("repo1 -> feature/test-branch");
+        _console.Output.ShouldContain("Dry run completed.");
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithAutomaticAndMerged_ShouldDeleteBranches()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+        _console.Output.ShouldContain("✓ repo1 -> feature/merged");
+        _console.Output.ShouldContain("Branch pruning completed.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithGoneOption_ShouldDeleteGoneBranches()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, false, true, null).Returns([GONE_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--gone", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, false, true, null);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, GONE_BRANCH);
+        _console.Output.ShouldContain("✓ repo1 -> feature/gone");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOlderThanOption_ShouldDeleteOldBranches()
+    {
+        // Arrange
+        const int OLDER_THAN_DAYS = 30;
+        const string OLD_BRANCH = "feature/old-branch";
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, false, false, OLDER_THAN_DAYS).Returns([OLD_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--older-than", "30", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, false, false, OLDER_THAN_DAYS);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, OLD_BRANCH);
+        _console.Output.ShouldContain("✓ repo1 -> feature/old-branch");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMultipleOptions_ShouldCombineCriteria()
+    {
+        // Arrange
+        const int OLDER_THAN_DAYS = 15;
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, true, OLDER_THAN_DAYS).Returns([MERGED_BRANCH, GONE_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--gone", "--older-than", "15", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, true, true, OLDER_THAN_DAYS);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, GONE_BRANCH);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMultipleRepositories_ShouldProcessAll()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH, REPO2_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _gitService.GetPrunableBranchesAsync(REPO2_PATH, true, false, null).Returns([GONE_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+        _display.GetHierarchicalName(REPO2_PATH, ROOT_DIR).Returns("repo2");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, true, false, null);
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO2_PATH, true, false, null);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO2_PATH, GONE_BRANCH);
+        _console.Output.ShouldContain("✓ repo1 -> feature/merged");
+        _console.Output.ShouldContain("✓ repo2 -> feature/gone");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenNoOptions_ShouldDefaultToMerged()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, true, false, null);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenDeleteFails_ShouldShowErrorAndContinue()
+    {
+        // Arrange
+        const string ERROR_MESSAGE = "error: branch 'feature/protected' not found.";
+        const string BRANCH2 = "feature/deletable";
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH, BRANCH2]);
+        _gitService.DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH).Returns(Task.FromException(new InvalidOperationException(ERROR_MESSAGE)));
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, BRANCH2);
+        _console.Output.ShouldContain($"✗ repo1 -> feature/merged: {ERROR_MESSAGE}");
+        _console.Output.ShouldContain("✓ repo1 -> feature/deletable");
+        _console.Output.ShouldContain("Branch pruning completed.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithShorthandAlias_ShouldWork()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "-a"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+        _console.Output.ShouldContain("✓ repo1 -> feature/merged");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNestedRepositories_ShouldUseHierarchicalNames()
+    {
+        // Arrange
+        const string NESTED_REPO = @"C:\repos\folder\nested-repo";
+        const string HIERARCHICAL_NAME = "folder/nested-repo";
+
+        _scanner.Scan(ROOT_DIR).Returns([NESTED_REPO]);
+        _gitService.GetPrunableBranchesAsync(NESTED_REPO, true, false, null).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(NESTED_REPO, ROOT_DIR).Returns(HIERARCHICAL_NAME);
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).DeleteLocalBranchAsync(NESTED_REPO, MERGED_BRANCH);
+        _console.Output.ShouldContain($"✓ {HIERARCHICAL_NAME} -> feature/merged");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithMixedResults_ShouldProcessAllRepositories()
+    {
+        // Arrange
+        const string REPO3_PATH = @"C:\repos\repo3";
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH, REPO2_PATH, REPO3_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _gitService.GetPrunableBranchesAsync(REPO2_PATH, true, false, null).Returns([]);
+        _gitService.GetPrunableBranchesAsync(REPO3_PATH, true, false, null).Returns([GONE_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+        _display.GetHierarchicalName(REPO3_PATH, ROOT_DIR).Returns("repo3");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, true, false, null);
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO2_PATH, true, false, null);
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO3_PATH, true, false, null);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(REPO2_PATH, Arg.Any<string>());
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO3_PATH, GONE_BRANCH);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithZeroOlderThan_ShouldPassCorrectValue()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, false, false, 0).Returns([]);
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--older-than", "0", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, false, false, 0);
+        _console.Output.ShouldContain("No branches to prune found.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithLargeOlderThanValue_ShouldWork()
+    {
+        // Arrange
+        const int LARGE_DAYS = 365;
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, false, false, LARGE_DAYS).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--older-than", "365", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, false, false, LARGE_DAYS);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+    }
+
+    [Theory]
+    [InlineData("--merged")]
+    [InlineData("--gone")]
+    [InlineData("--older-than", "7")]
+    public async Task ExecuteAsync_WithSingleOption_ShouldUseCorrectCriteria(params string[] args)
+    {
+        // Arrange
+        var expectedMerged = args.Contains("--merged");
+        var expectedGone = args.Contains("--gone");
+        var expectedOlderThan = args.Contains("--older-than") ? 7 : (int?)null;
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, expectedMerged, expectedGone, expectedOlderThan).Returns([]);
+
+        var commandArgs = new List<string> { ROOT_DIR };
+        commandArgs.AddRange(args);
+        commandArgs.Add("--automatic");
+
+        // Act
+        await _command.Parse([.. commandArgs]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).GetPrunableBranchesAsync(REPO1_PATH, expectedMerged, expectedGone, expectedOlderThan);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenScannerReturnsEmptyList_ShouldNotCallGitService()
+    {
+        // Arrange
+        _scanner.Scan(ROOT_DIR).Returns([]);
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.DidNotReceive().GetPrunableBranchesAsync(Arg.Any<string>(), Arg.Any<bool>(), Arg.Any<bool>(), Arg.Any<int?>());
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
         _console.Output.ShouldContain("No Git repositories found.");
     }
 
     [Fact]
-    public async Task ExecuteAsync_DryRun_ShouldNotDeleteBranches()
+    public async Task ExecuteAsync_WithComplexBranchNames_ShouldHandleCorrectly()
     {
         // Arrange
-        _scanner.Scan("C:/repos").Returns(["C:/repos/repo1"]);
-        _gitService.GetPrunableBranchesAsync("C:/repos/repo1", true, false, null).Returns(["feature"]);
-        _display.GetHierarchicalName("C:/repos/repo1", "C:/repos").Returns("repo1");
+        const string COMPLEX_BRANCH1 = "feature/JIRA-123_implement-new-feature";
+        const string COMPLEX_BRANCH2 = "bugfix/fix-issue#456";
+        const string COMPLEX_BRANCH3 = "release/v1.2.3-beta";
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([COMPLEX_BRANCH1, COMPLEX_BRANCH2, COMPLEX_BRANCH3]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
 
         // Act
-        await _command.Parse(["C:/repos", "--dry-run"]).InvokeAsync();
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
 
         // Assert
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, COMPLEX_BRANCH1);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, COMPLEX_BRANCH2);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, COMPLEX_BRANCH3);
+        _console.Output.ShouldContain("✓ repo1 -> feature/JIRA-123_implement-new-feature");
+        _console.Output.ShouldContain("✓ repo1 -> bugfix/fix-issue#456");
+        _console.Output.ShouldContain("✓ repo1 -> release/v1.2.3-beta");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithPartialDeleteFailures_ShouldContinueAndReportCorrectly()
+    {
+        // Arrange
+        const string SUCCESS_BRANCH = "feature/success";
+        const string FAIL_BRANCH = "feature/fail";
+        const string SUCCESS_BRANCH2 = "feature/success2";
+        const string ERROR_MESSAGE = "Branch is protected";
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([SUCCESS_BRANCH, FAIL_BRANCH, SUCCESS_BRANCH2]);
+        _gitService.DeleteLocalBranchAsync(REPO1_PATH, FAIL_BRANCH).Returns(Task.FromException(new InvalidOperationException(ERROR_MESSAGE)));
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, SUCCESS_BRANCH);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, FAIL_BRANCH);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, SUCCESS_BRANCH2);
+
+        _console.Output.ShouldContain("✓ repo1 -> feature/success");
+        _console.Output.ShouldContain($"✗ repo1 -> feature/fail: {ERROR_MESSAGE}");
+        _console.Output.ShouldContain("✓ repo1 -> feature/success2");
+        _console.Output.ShouldContain("Branch pruning completed.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenUserSelectsNoBranches_ShouldShowMessageAndExit()
+    {
+        // Arrange
+        _console.Input.PushTextWithEnter(""); // Simula usuário não selecionando nada
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged"]).InvokeAsync();
+
+        // Assert
+        _console.Output.ShouldContain("No branch selected.");
         await _gitService.DidNotReceive().DeleteLocalBranchAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<bool>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithInteractiveMode_ShouldUseConverter()
+    {
+        // Arrange
+        _console.Input.PushKey(ConsoleKey.Spacebar); // Select first option
+        _console.Input.PushKey(ConsoleKey.Enter);    // Confirm selection
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([MERGED_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged"]).InvokeAsync();
+
+        // Assert - The UseConverter lambda should be called when displaying options
+        // This verifies that GetHierarchicalName is called from within the converter
+        _display.Received().GetHierarchicalName(REPO1_PATH, ROOT_DIR);
+        await _gitService.Received(1).DeleteLocalBranchAsync(REPO1_PATH, MERGED_BRANCH);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithDetachedHeadBranches_ShouldFilterOutDetachedHeads()
+    {
+        // Arrange
+        const string NORMAL_BRANCH = "custom";
+        const string SUBMODULE_REPO = @"C:\repos\pos\_colibri-lib";
+        const string MAIN_REPO = @"C:\repos\sourcegit";
+
+        _scanner.Scan(ROOT_DIR).Returns([MAIN_REPO, SUBMODULE_REPO]);
+        // Main repo has a normal branch that should be pruned
+        _gitService.GetPrunableBranchesAsync(MAIN_REPO, true, false, null).Returns([NORMAL_BRANCH]);
+        // Submodule has detached HEAD which should NOT be returned by GetPrunableBranchesAsync
+        _gitService.GetPrunableBranchesAsync(SUBMODULE_REPO, true, false, null).Returns([]);
+        _display.GetHierarchicalName(MAIN_REPO, ROOT_DIR).Returns("sourcegit");
+        _display.GetHierarchicalName(SUBMODULE_REPO, ROOT_DIR).Returns("pos/_colibri-lib");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert - Only normal branches should be deleted, not detached heads
+        await _gitService.Received(1).DeleteLocalBranchAsync(MAIN_REPO, NORMAL_BRANCH);
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(SUBMODULE_REPO, Arg.Any<string>());
+        _console.Output.ShouldContain("✓ sourcegit -> custom");
+        _console.Output.ShouldNotContain("detached");
+        _console.Output.ShouldContain("Branch pruning completed.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithComplexBranchNamesInInteractiveMode_ShouldFormatCorrectly()
+    {
+        // Arrange
+        const string DETACHED_HEAD_BRANCH = "(HEAD detached at 3883cba)";
+        const string COMPLEX_BRANCH = "feature/JIRA-123_implement-new-feature";
+
+        _console.Input.PushKey(ConsoleKey.Spacebar); // Select first option
+        _console.Input.PushKey(ConsoleKey.Enter);    // Confirm selection
+
+        _scanner.Scan(ROOT_DIR).Returns([REPO1_PATH]);
+        _gitService.GetPrunableBranchesAsync(REPO1_PATH, true, false, null).Returns([DETACHED_HEAD_BRANCH, COMPLEX_BRANCH]);
+        _display.GetHierarchicalName(REPO1_PATH, ROOT_DIR).Returns("repo1");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged"]).InvokeAsync();
+
+        // Assert - Verify that UseConverter handles complex branch names correctly
+        // The converter should split correctly even with spaces and special characters
+        _display.Received().GetHierarchicalName(REPO1_PATH, ROOT_DIR);
+        // Note: We're testing that the converter doesn't crash with complex branch names
+        // The actual deletion depends on user selection in interactive mode
+    }
+
+    [Fact]
+    public void UseConverter_WithValidBranchKey_ShouldFormatCorrectly()
+    {
+        // Arrange
+        const string REPO_PATH = @"C:\repos\pos\_colibri-lib";
+        const string DETACHED_BRANCH = "(HEAD detached at def63d2)";
+        const string EXPECTED_KEY = @"C:\repos\pos\_colibri-lib|(HEAD detached at def63d2)";
+
+        _display.GetHierarchicalName(REPO_PATH, ROOT_DIR).Returns("pos/_colibri-lib");
+
+        // Create a new command instance to test the converter
+        _ = new PruneBranchesCommand(_scanner, _gitService, new TestConsole(), _display);
+
+        // Act - Test the converter logic indirectly by verifying the key format
+        // The branchKeys format should be: "repositoryPath|branchName"
+        var expectedKeyFormat = $"{REPO_PATH}|{DETACHED_BRANCH}";
+
+        // Assert - Verify that the key format matches expected pattern
+        expectedKeyFormat.ShouldBe(EXPECTED_KEY);
+        expectedKeyFormat.Split('|', 2).Length.ShouldBe(2);
+        expectedKeyFormat.Split('|', 2)[0].ShouldBe(REPO_PATH);
+        expectedKeyFormat.Split('|', 2)[1].ShouldBe(DETACHED_BRANCH);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithSubmodulesAndDetachedHeads_ShouldFilterOutDetachedHeads()
+    {
+        // Arrange - Simulates the scenario where detached heads should be filtered out
+        const string SOURCEGIT_REPO = @"C:\repos\sourcegit";
+        const string COLIBRI_REPO = @"C:\repos\pos\_colibri-lib";
+        const string AGILE_REPO = @"C:\repos\pos\_agile-lib";
+        const string KIOSK_REPO = @"C:\repos\kiosk\_sdk";
+        const string DCONNECT_REPO = @"C:\repos\dconnect\_sdk";
+
+        const string CUSTOM_BRANCH = "custom";
+        // Detached heads should NOT be returned by GetPrunableBranchesAsync after our fix
+
+        _scanner.Scan(ROOT_DIR).Returns([SOURCEGIT_REPO, COLIBRI_REPO, AGILE_REPO, KIOSK_REPO, DCONNECT_REPO]);
+        _gitService.GetPrunableBranchesAsync(SOURCEGIT_REPO, true, false, null).Returns([CUSTOM_BRANCH]);
+        // All submodules with detached heads should return empty lists (filtered out)
+        _gitService.GetPrunableBranchesAsync(COLIBRI_REPO, true, false, null).Returns([]);
+        _gitService.GetPrunableBranchesAsync(AGILE_REPO, true, false, null).Returns([]);
+        _gitService.GetPrunableBranchesAsync(KIOSK_REPO, true, false, null).Returns([]);
+        _gitService.GetPrunableBranchesAsync(DCONNECT_REPO, true, false, null).Returns([]);
+
+        _display.GetHierarchicalName(SOURCEGIT_REPO, ROOT_DIR).Returns("sourcegit");
+        _display.GetHierarchicalName(COLIBRI_REPO, ROOT_DIR).Returns("pos/_colibri-lib");
+        _display.GetHierarchicalName(AGILE_REPO, ROOT_DIR).Returns("pos/_agile-lib");
+        _display.GetHierarchicalName(KIOSK_REPO, ROOT_DIR).Returns("kiosk/_sdk");
+        _display.GetHierarchicalName(DCONNECT_REPO, ROOT_DIR).Returns("dconnect/_sdk");
+
+        // Act
+        await _command.Parse([ROOT_DIR, "--merged", "--automatic"]).InvokeAsync();
+
+        // Assert - Only the normal branch should be processed, detached heads filtered out
+        await _gitService.Received(1).DeleteLocalBranchAsync(SOURCEGIT_REPO, CUSTOM_BRANCH);
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(COLIBRI_REPO, Arg.Any<string>());
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(AGILE_REPO, Arg.Any<string>());
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(KIOSK_REPO, Arg.Any<string>());
+        await _gitService.DidNotReceive().DeleteLocalBranchAsync(DCONNECT_REPO, Arg.Any<string>());
+
+        // Verify only the normal branch appears in output
+        _console.Output.ShouldContain("✓ sourcegit -> custom");
+        _console.Output.ShouldNotContain("detached");
+        _console.Output.ShouldContain("Branch pruning completed.");
     }
 }

--- a/GitTools.Tests/Services/GitServiceTests.cs
+++ b/GitTools.Tests/Services/GitServiceTests.cs
@@ -22,6 +22,8 @@ public sealed class GitServiceTests
     private const string REPO_NAME = "test-repo";
     private const string TAG_NAME = "v1.0.0";
     private const string GIT_DIR = ".git";
+    private const string MAIN_BRANCH = "main";
+    private const string DEVELOP_BRANCH = "develop";
     private const string REMOTE_URL = "https://github.com/user/repo.git";
     private const string CURRENT_DIRECTORY = "C:/current";
 
@@ -2176,22 +2178,7 @@ public sealed class GitServiceTests
         _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
 
         _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
-            .Returns(static callInfo =>
-            {
-                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
-                var psi = callInfo.ArgAt<ProcessStartInfo>(0);
-
-                if (psi.Arguments.Contains("config --get remote.origin.url"))
-                {
-                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(REMOTE_LOCAL_URL));
-                }
-                else if (psi.Arguments.Contains("branch --format") || psi.Arguments.Contains("status --porcelain"))
-                {
-                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(""));
-                }
-
-                return 0;
-            });
+            .Returns(static callInfo => MockNoBranchesGitProcess(callInfo, REMOTE_LOCAL_URL));
 
         // Act
         var result = await _gitService.GetRepositoryStatusAsync(REPO_PATH, ROOT_DIR);
@@ -2205,6 +2192,56 @@ public sealed class GitServiceTests
         result.LocalBranches.ShouldBeEmpty();
         result.ErrorMessage.ShouldBe(EXPECTED_ERROR);
         result.HasErrors.ShouldBeTrue();
+    }
+
+    // ReSharper disable once CyclomaticComplexity
+    private static int MockNoBranchesGitProcess(NSubstitute.Core.CallInfo callInfo, string REMOTE_LOCAL_URL)
+    {
+        var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+        var psi = callInfo.ArgAt<ProcessStartInfo>(0);
+
+        if (psi.Arguments.Contains("config --get remote.origin.url"))
+        {
+            outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(REMOTE_LOCAL_URL));
+        }
+        else if (psi.Arguments.Contains("branch --format") || psi.Arguments.Contains("status --porcelain"))
+        {
+            outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(""));
+        }
+        else if (psi.Arguments.Contains("for-each-ref"))
+        {
+            // Mock upstream tracking for main and develop, but not feature
+            if (psi.Arguments.Contains($"refs/heads/{MAIN_BRANCH}"))
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("origin/main"));
+            else if (psi.Arguments.Contains($"refs/heads/{DEVELOP_BRANCH}"))
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("origin/develop"));
+            else
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(""));
+        }
+        else if (psi.Arguments.Contains("show-ref"))
+        {
+            // Mock remote ref existence for tracked branches
+            if (psi.Arguments.Contains("origin/main") || psi.Arguments.Contains("origin/develop"))
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs($"abc123 refs/remotes/{psi.Arguments.Split(' ')[1]}"));
+            else
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(""));
+        }
+        else if (psi.Arguments.Contains("rev-parse --abbrev-ref HEAD"))
+        {
+            outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MAIN_BRANCH));
+        }
+        else if (psi.Arguments.Contains("rev-list --left-right --count"))
+        {
+            // Mock ahead/behind counts
+            if (psi.Arguments.Contains($"{MAIN_BRANCH}...origin/{MAIN_BRANCH}"))
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("0\t2"));
+            else if (psi.Arguments.Contains($"{DEVELOP_BRANCH}...origin/{DEVELOP_BRANCH}"))
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("1\t0"));
+            else
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("0\t0"));
+        }
+
+        return 0;
     }
 
     [Fact]
@@ -2238,9 +2275,7 @@ public sealed class GitServiceTests
         // Arrange
         const string ROOT_DIR = @"C:\repos";
         const string REMOTE_LOCAL_URL = "https://github.com/user/repo.git";
-        const string MAIN_BRANCH = "main";
         const string FEATURE_BRANCH = "feature/new-feature";
-        const string DEVELOP_BRANCH = "develop";
 
         _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
 
@@ -2283,7 +2318,8 @@ public sealed class GitServiceTests
                 {
                     // Mock remote ref existence for tracked branches
                     if (psi.Arguments.Contains("origin/main") || psi.Arguments.Contains("origin/develop"))
-                        outputHandler?.Invoke(null!, CreateDataReceivedEventArgs($"abc123 refs/remotes/{psi.Arguments.Split(' ')[1]}"));                    else
+                        outputHandler?.Invoke(null!, CreateDataReceivedEventArgs($"abc123 refs/remotes/{psi.Arguments.Split(' ')[1]}"));
+                    else
                         outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(""));
                 }
                 else if (psi.Arguments.Contains("rev-parse --abbrev-ref HEAD"))
@@ -3012,38 +3048,6 @@ public sealed class GitServiceTests
     }
 
     [Fact]
-    public async Task GetPrunableBranchesAsync_WithMergedOption_ShouldReturnBranches()
-    {
-        // Arrange
-        const string MERGED_OUTPUT = "feature/one\nfeature/two";
-        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
-
-        _processRunner.RunAsync(
-            Arg.Any<ProcessStartInfo>(),
-            Arg.Any<DataReceivedEventHandler>(),
-            Arg.Any<DataReceivedEventHandler>())
-            .Returns(callInfo =>
-            {
-                var psi = callInfo.Arg<ProcessStartInfo>();
-                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
-
-                if (psi.Arguments.Contains("branch --merged"))
-                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MERGED_OUTPUT));
-                else if (psi.Arguments.Contains("rev-parse"))
-                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("main"));
-
-                return 0;
-            });
-
-        // Act
-        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: false, olderThanDays: null);
-
-        // Assert
-        result.ShouldContain("feature/one");
-        result.ShouldContain("feature/two");
-    }
-
-    [Fact]
     public async Task GetPrunableBranchesAsync_ShouldExcludeProtectedBranches()
     {
         // Arrange
@@ -3073,5 +3077,829 @@ public sealed class GitServiceTests
         // Assert
         result.ShouldNotContain("main");
         result.ShouldContain("feature/old");
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WithOlderThanAndDetachedHead_ShouldFilterOutDetachedHead()
+    {
+        // Arrange
+        const int OLDER_THAN_DAYS = 30;
+        const string OLD_NORMAL_BRANCH = "feature/old-branch";
+        const string OLD_DETACHED_BRANCH = "HEAD detached at abc123";
+
+        var threshold = DateTimeOffset.UtcNow.AddDays(-OLDER_THAN_DAYS - 1);
+        var thresholdIso = threshold.ToString("yyyy-MM-dd HH:mm:ss zzz");
+
+        var dateOutput = $"{thresholdIso}|{OLD_NORMAL_BRANCH}\n{thresholdIso}|{OLD_DETACHED_BRANCH}";
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync
+        (
+            Arg.Is<ProcessStartInfo>
+            (
+                psi => psi.Arguments
+                    .Contains("for-each-ref --format='%(committerdate:iso8601)|%(refname:short)' refs/heads")
+            ),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(Task.FromResult(0))
+            .AndDoes(callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                foreach (var line in dateOutput.Split('\n'))
+                {
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(line));
+                }
+            });
+
+        _processRunner.RunAsync
+        (
+            Arg.Is<ProcessStartInfo>(psi => psi.Arguments.Contains("rev-parse --abbrev-ref HEAD")),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(Task.FromResult(0))
+            .AndDoes(callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MAIN_BRANCH));
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, false, false, OLDER_THAN_DAYS);
+
+        // Assert
+        result.ShouldContain(OLD_NORMAL_BRANCH);
+        result.ShouldNotContain(OLD_DETACHED_BRANCH);
+        result.ShouldNotContain("HEAD");
+        result.ShouldNotContain("detached");
+
+        await _processRunner.Received(2).RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>());
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenBranchExists_ShouldReturnBranchName()
+    {
+        // Arrange
+        const string CURRENT_BRANCH = "main";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(static callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(CURRENT_BRANCH));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(REPO_PATH);
+
+        // Assert
+        result.ShouldBe(CURRENT_BRANCH);
+
+        await _processRunner.Received(1).RunAsync
+        (
+            Arg.Is<ProcessStartInfo>(static psi =>
+                psi.FileName == "git" &&
+                psi.Arguments == "rev-parse --abbrev-ref HEAD" &&
+                psi.WorkingDirectory == REPO_PATH),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenBranchHasWhitespace_ShouldReturnTrimmedBranchName()
+    {
+        // Arrange
+        const string CURRENT_BRANCH = "  feature/test-branch  ";
+        const string EXPECTED_BRANCH = "feature/test-branch";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(static callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(CURRENT_BRANCH));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(REPO_PATH);
+
+        // Assert
+        result.ShouldBe(EXPECTED_BRANCH);
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenOutputIsEmpty_ShouldReturnNull()
+    {
+        // Arrange
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(static callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(""));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(REPO_PATH);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenOutputIsWhitespace_ShouldReturnNull()
+    {
+        // Arrange
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(static callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("   "));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(REPO_PATH);
+
+        // Assert
+        result.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenRepositoryPathIsNull_ShouldReturnNull()
+    {
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(null!);
+
+        // Assert
+        result.ShouldBeNull();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenRepositoryPathIsEmpty_ShouldReturnNull()
+    {
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(string.Empty);
+
+        // Assert
+        result.ShouldBeNull();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenRepositoryDoesNotExist_ShouldReturnNull()
+    {
+        // Arrange
+        const string NON_EXISTENT_REPO_PATH = @"C:\non\existent\repo";
+        _fileSystem.Directory.Exists(NON_EXISTENT_REPO_PATH).Returns(false);
+
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(NON_EXISTENT_REPO_PATH);
+
+        // Assert
+        result.ShouldBeNull();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetCurrentBranchAsync_WhenGitCommandFails_ShouldReturnNullAndLogError()
+    {
+        // Arrange
+        const string ERROR_MESSAGE = "Git error occurred";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns<int>(static _ => throw new InvalidOperationException(ERROR_MESSAGE));
+
+        // Act
+        var result = await _gitService.GetCurrentBranchAsync(REPO_PATH);
+
+        // Assert
+        result.ShouldBeNull();
+        _console.Output.ShouldContain("Error retrieving current branch");
+        _console.Output.ShouldContain(REPO_PATH);
+        _console.Output.ShouldContain(ERROR_MESSAGE);
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenMergedBranchesRequested_ShouldReturnMergedBranches()
+    {
+        // Arrange
+        const string MERGED_BRANCHES_OUTPUT = """
+            'feature/branch1'
+            'feature/branch2'
+            'main'
+            """;
+        const string CURRENT_BRANCH = "main";
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+                var psi = callInfo.ArgAt<ProcessStartInfo>(0);
+
+                if (psi.Arguments.Contains("branch --merged"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MERGED_BRANCHES_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse --abbrev-ref HEAD"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(CURRENT_BRANCH));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldContain("feature/branch1");
+        result.ShouldContain("feature/branch2");
+        result.ShouldNotContain("main"); // Protected branch
+        result.ShouldNotContain("master"); // Protected branch
+        result.ShouldNotContain("develop"); // Protected branch
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WithMergedOption_ShouldReturnBranches()
+    {
+        // Arrange
+        const string MERGED_OUTPUT = "feature/one\nfeature/two";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("branch --merged"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MERGED_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("main"));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldContain("feature/one");
+        result.ShouldContain("feature/two");
+        result.ShouldNotContain("main"); // Protected branch
+        result.ShouldNotContain("develop"); // Protected branch
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenGoneBranchesRequested_ShouldReturnGoneBranches()
+    {
+        // Arrange
+        const string GONE_OUTPUT = """
+              feature/gone1    abc123 [origin/feature/gone1: gone] Last commit
+            * main             def456 [origin/main] Current branch
+              feature/gone2    ghi789 [origin/feature/gone2: gone] Another commit
+            """;
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("branch -vv"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(GONE_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("main"));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: false, gone: true, olderThanDays: null);
+
+        // Assert
+        result.ShouldContain("feature/gone1");
+        result.ShouldContain("feature/gone2");
+        result.ShouldNotContain("main");
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenOlderThanDaysRequested_ShouldReturnOldBranches()
+    {
+        // Arrange
+        const int OLDER_THAN_DAYS = 30;
+        var oldDate = DateTimeOffset.UtcNow.AddDays(-40).ToString("yyyy-MM-ddTHH:mm:sszzz");
+        var recentDate = DateTimeOffset.UtcNow.AddDays(-10).ToString("yyyy-MM-ddTHH:mm:sszzz");
+
+        var dateOutput = $"""
+            {oldDate}|feature/old-branch
+            {recentDate}|feature/recent-branch
+            {oldDate}|main
+            """;
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("for-each-ref --format"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(dateOutput));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: false, gone: false, olderThanDays: OLDER_THAN_DAYS);
+
+        // Assert
+        result.ShouldContain("feature/old-branch");
+        result.ShouldNotContain("feature/recent-branch");
+        result.ShouldNotContain("main"); // Protected branch
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenMultipleCriteriaProvided_ShouldReturnUnionOfResults()
+    {
+        // Arrange
+        const string MERGED_BRANCHES_OUTPUT = "'feature/merged1'\n'feature/merged2'";
+        const string GONE_BRANCHES_OUTPUT = "  feature/gone1    abc123 [origin/feature/gone1: gone] Last commit";
+        var oldDate = DateTimeOffset.UtcNow.AddDays(-40).ToString("yyyy-MM-ddTHH:mm:sszzz");
+        var dateOutput = $"{oldDate}|feature/old-branch";
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("branch --merged"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MERGED_BRANCHES_OUTPUT));
+                else if (psi.Arguments.Contains("branch -vv"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(GONE_BRANCHES_OUTPUT));
+                else if (psi.Arguments.Contains("for-each-ref --format"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(dateOutput));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: true, olderThanDays: 30);
+
+        // Assert
+        result.ShouldContain("feature/merged1");
+        result.ShouldContain("feature/merged2");
+        result.ShouldContain("feature/gone1");
+        result.ShouldContain("feature/old-branch");
+        result.Count.ShouldBe(4);
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenCurrentBranchIsInResults_ShouldExcludeCurrentBranch()
+    {
+        // Arrange
+        const string CURRENT_BRANCH = "feature/current";
+        const string MERGED_BRANCHES_OUTPUT = """
+            main
+            feature/normal-branch
+            (HEAD detached at abc1234)
+            """;
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("branch --merged"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MERGED_BRANCHES_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse --abbrev-ref HEAD"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(CURRENT_BRANCH));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldContain("feature/normal-branch");
+        result.ShouldNotContain("main"); // Protected branch
+        result.ShouldNotContain("feature/current"); // Current branch should be filtered out
+        result.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenRepositoryPathIsNull_ShouldReturnEmptyList()
+    {
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(null!, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldBeEmpty();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenRepositoryPathIsEmpty_ShouldReturnEmptyList()
+    {
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(string.Empty, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldBeEmpty();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenRepositoryDoesNotExist_ShouldReturnEmptyList()
+    {
+        // Arrange
+        const string NON_EXISTENT_REPO_PATH = @"C:\non\existent\repo";
+        _fileSystem.Directory.Exists(NON_EXISTENT_REPO_PATH).Returns(false);
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(NON_EXISTENT_REPO_PATH, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldBeEmpty();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenGitCommandFails_ShouldReturnEmptyListAndLogError()
+    {
+        // Arrange
+        const string ERROR_MESSAGE = "Git command failed";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns<int>(static _ => throw new InvalidOperationException(ERROR_MESSAGE));
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldBeEmpty();
+        _console.Output.ShouldContain("Error getting prunable branches");
+        _console.Output.ShouldContain(REPO_PATH);
+        _console.Output.ShouldContain(ERROR_MESSAGE);
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenNoCriteriaProvided_ShouldReturnEmptyList()
+    {
+        // Arrange
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: false, gone: false, olderThanDays: null);
+
+        // Assert
+        result.ShouldBeEmpty();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WhenInvalidDateFormat_ShouldSkipInvalidEntries()
+    {
+        // Arrange
+        const string DATE_OUTPUT = """
+            2024-01-15T10:30:00+00:00|feature/valid-date
+            invalid-date|feature/invalid-date
+            |feature/empty-date
+            """;
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("for-each-ref"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(DATE_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("main"));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: false, gone: false, olderThanDays: 60);
+
+        // Assert - Only valid entries should be included
+        result.ShouldContain("feature/valid-date");
+        result.ShouldNotContain("feature/invalid-date");
+        result.ShouldNotContain("feature/empty-date");
+        result.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WithDetachedHeadBranches_ShouldFilterOutDetachedHeads()
+    {
+        // Arrange
+        const string MERGED_OUTPUT = """
+            main
+            feature/normal-branch
+            (HEAD detached at abc1234)
+            """;
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("branch --merged"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(MERGED_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse --abbrev-ref HEAD"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("main"));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: true, gone: false, olderThanDays: null);
+
+        // Assert - Should exclude detached head and protected branches
+        result.ShouldContain("feature/normal-branch");
+        result.ShouldNotContain("main"); // Protected branch
+        result.ShouldNotContain("feature/current"); // Current branch should be filtered out
+        result.Count.ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task GetPrunableBranchesAsync_WithGoneBranchesIncludingDetached_ShouldFilterOutDetachedHeads()
+    {
+        // Arrange
+        const string GONE_OUTPUT = """
+              feature/gone1    abc123 [origin/feature/gone1: gone] Last commit
+            * main             def456 [origin/main] Current branch
+              feature/gone2    ghi789 [origin/feature/gone2: gone] Another commit
+              (HEAD detached at xyz)  123abcd [origin/detached: gone]
+            """;
+
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>())
+            .Returns(callInfo =>
+            {
+                var psi = callInfo.Arg<ProcessStartInfo>();
+                var outputHandler = callInfo.ArgAt<DataReceivedEventHandler>(1);
+
+                if (psi.Arguments.Contains("branch -vv"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs(GONE_OUTPUT));
+                else if (psi.Arguments.Contains("rev-parse"))
+                    outputHandler?.Invoke(null!, CreateDataReceivedEventArgs("main"));
+
+                return 0;
+            });
+
+        // Act
+        var result = await _gitService.GetPrunableBranchesAsync(REPO_PATH, merged: false, gone: true, olderThanDays: null);
+
+        // Assert - Should include only normal gone branches, not detached heads
+        result.ShouldContain("feature/gone1");
+        result.ShouldContain("feature/gone2");
+        result.ShouldNotContain("main");
+    }
+
+    [Fact]
+    public async Task DeleteLocalBranchAsync_WhenBranchExists_ShouldCallGitBranchDelete()
+    {
+        // Arrange
+        const string BRANCH_NAME = "feature/test-branch";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(0);
+
+        // Act
+        await _gitService.DeleteLocalBranchAsync(REPO_PATH, BRANCH_NAME);
+
+        // Assert
+        await _processRunner.Received(1).RunAsync
+        (
+            Arg.Is<ProcessStartInfo>(psi =>
+                psi.FileName == "git" &&
+                psi.Arguments == $"branch -d {BRANCH_NAME}" &&
+                psi.WorkingDirectory == REPO_PATH),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteLocalBranchAsync_WhenForceIsTrue_ShouldCallGitBranchDeleteWithForceFlag()
+    {
+        // Arrange
+        const string BRANCH_NAME = "feature/test-branch";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(0);
+
+        // Act
+        await _gitService.DeleteLocalBranchAsync(REPO_PATH, BRANCH_NAME, force: true);
+
+        // Assert
+        await _processRunner.Received(1).RunAsync
+        (
+            Arg.Is<ProcessStartInfo>(psi =>
+                psi.FileName == "git" &&
+                psi.Arguments == $"branch -D {BRANCH_NAME}" &&
+                psi.WorkingDirectory == REPO_PATH),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteLocalBranchAsync_WhenRepositoryPathIsNull_ShouldThrowException()
+    {
+        // Arrange
+        const string BRANCH_NAME = "feature/test-branch";
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<ArgumentNullException>(
+            () => _gitService.DeleteLocalBranchAsync(null!, BRANCH_NAME));
+
+        exception.ShouldNotBeNull();
+
+        await _processRunner.DidNotReceive().RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task DeleteLocalBranchAsync_WhenBranchNameIsNullOrWhitespace_ShouldCallGitWithInvalidBranch(string? branchName)
+    {
+        // Arrange
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns<int>(_ => throw new InvalidOperationException("error: branch '' not found."));
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(
+            () => _gitService.DeleteLocalBranchAsync(REPO_PATH, branchName!));
+
+        exception.ShouldNotBeNull();
+
+        await _processRunner.Received(1).RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteLocalBranchAsync_WhenGitCommandFails_ShouldThrowException()
+    {
+        // Arrange
+        const string BRANCH_NAME = "feature/test-branch";
+        const string ERROR_MESSAGE = "error: branch 'feature/test-branch' not found.";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns<int>(_ => throw new InvalidOperationException(ERROR_MESSAGE));
+
+        // Act & Assert
+        var exception = await Should.ThrowAsync<InvalidOperationException>(
+            () => _gitService.DeleteLocalBranchAsync(REPO_PATH, BRANCH_NAME));
+
+        exception.Message.ShouldBe(ERROR_MESSAGE);
+
+        await _processRunner.Received(1).RunAsync
+        (
+            Arg.Any<ProcessStartInfo>(),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
+    }
+
+    [Fact]
+    public async Task DeleteLocalBranchAsync_WhenBranchHasSpecialCharacters_ShouldPassCorrectArguments()
+    {
+        // Arrange
+        const string BRANCH_NAME = "feature/test-branch-with-special#chars";
+        _fileSystem.Directory.Exists(REPO_PATH).Returns(true);
+
+        _processRunner.RunAsync(Arg.Any<ProcessStartInfo>(), Arg.Any<DataReceivedEventHandler>(), Arg.Any<DataReceivedEventHandler>())
+            .Returns(0);
+
+        // Act
+        await _gitService.DeleteLocalBranchAsync(REPO_PATH, BRANCH_NAME);
+
+        // Assert
+        await _processRunner.Received(1).RunAsync
+        (
+            Arg.Is<ProcessStartInfo>(psi =>
+                psi.FileName == "git" &&
+                psi.Arguments == $"branch -d {BRANCH_NAME}" &&
+                psi.WorkingDirectory == REPO_PATH),
+            Arg.Any<DataReceivedEventHandler>(),
+            Arg.Any<DataReceivedEventHandler>()
+        );
     }
 }

--- a/GitTools/Commands/PruneBranchesCommand.cs
+++ b/GitTools/Commands/PruneBranchesCommand.cs
@@ -139,9 +139,6 @@ public sealed class PruneBranchesCommand : Command
                 .AddChoiceGroup("Select all", branchKeys)
                 .UseConverter(key =>
                 {
-                    if (key == "Select all")
-                        return key;
-
                     var parts = key.Split('|', 2);
                     var repo = parts[0];
                     var branch = parts[1];

--- a/GitTools/Commands/PruneBranchesCommand.cs
+++ b/GitTools/Commands/PruneBranchesCommand.cs
@@ -1,0 +1,207 @@
+using System.CommandLine;
+using GitTools.Services;
+using Spectre.Console;
+
+namespace GitTools.Commands;
+
+/// <summary>
+/// Command for pruning local branches across multiple repositories.
+/// </summary>
+public sealed class PruneBranchesCommand : Command
+{
+    private readonly IGitRepositoryScanner _scanner;
+    private readonly IGitService _gitService;
+    private readonly IAnsiConsole _console;
+    private readonly IConsoleDisplayService _displayService;
+
+    public PruneBranchesCommand(IGitRepositoryScanner scanner, IGitService gitService, IAnsiConsole console, IConsoleDisplayService displayService)
+        : base("prune-branches", "Prunes local branches in git repositories.")
+    {
+        _scanner = scanner;
+        _gitService = gitService;
+        _console = console;
+        _displayService = displayService;
+
+
+        var rootArg = new Argument<string>("root-directory")
+        {
+            Description = "Root directory of git repositories",
+            Arity = ArgumentArity.ExactlyOne
+        };
+
+        var mergedOption = new Option<bool>("--merged")
+        {
+            Description = "Include branches already merged into HEAD"
+        };
+
+        var goneOption = new Option<bool>("--gone")
+        {
+            Description = "Include branches whose upstream no longer exists"
+        };
+
+        var olderThanOption = new Option<int?>("--older-than")
+        {
+            Description = "Include branches with last commit older than specified days",
+            Arity = ArgumentArity.ZeroOrOne
+        };
+
+        var automaticOption = new Option<bool>("--automatic", "-a")
+        {
+            Description = "Run without prompting for confirmation"
+        };
+
+        var dryRunOption = new Option<bool>("--dry-run")
+        {
+            Description = "Show what would be done without deleting branches"
+        };
+
+        Arguments.Add(rootArg);
+        Options.Add(mergedOption);
+        Options.Add(goneOption);
+        Options.Add(olderThanOption);
+        Options.Add(automaticOption);
+        Options.Add(dryRunOption);
+
+        SetAction(
+            parseResult => ExecuteAsync(
+                parseResult.GetValue(rootArg)!,
+                parseResult.GetValue(mergedOption),
+                parseResult.GetValue(goneOption),
+                parseResult.GetValue(olderThanOption),
+                parseResult.GetValue(automaticOption),
+                parseResult.GetValue(dryRunOption)));
+    }
+
+    private async Task ExecuteAsync(string rootDirectory, bool merged, bool gone, int? olderThan, bool automatic, bool dryRun)
+    {
+        if (!merged && !gone && olderThan is null)
+            merged = true;
+
+        var repoPaths = _console.Status()
+            .Start($"[yellow]Scanning for Git repositories in {rootDirectory}...[/]", _ => _scanner.Scan(rootDirectory));
+
+        if (repoPaths.Count == 0)
+        {
+            _console.MarkupLine("[yellow]No Git repositories found.[/]");
+            return;
+        }
+
+        var repoBranches = await _console.Progress()
+            .Columns(new ProgressBarColumn
+                {
+                    CompletedStyle = new Style(foreground: Color.Green1, decoration: Decoration.Conceal | Decoration.Bold | Decoration.Invert),
+                    RemainingStyle = new Style(decoration: Decoration.Conceal),
+                    FinishedStyle = new Style(foreground: Color.Green1, decoration: Decoration.Conceal | Decoration.Bold | Decoration.Invert)
+                },
+                new PercentageColumn(),
+                new SpinnerColumn(),
+                new TaskDescriptionColumn())
+            .StartAsync(async ctx =>
+            {
+                var result = new Dictionary<string, List<string>>();
+                var task = ctx.AddTask("Analyzing repositories...");
+                task.MaxValue = repoPaths.Count;
+
+                foreach (var repo in repoPaths)
+                {
+                    task.Description($"Checking {_displayService.GetHierarchicalName(repo, rootDirectory)}...");
+                    var branches = await _gitService.GetPrunableBranchesAsync(repo, merged, gone, olderThan).ConfigureAwait(false);
+                    if (branches.Count > 0)
+                        result[repo] = branches;
+                    task.Increment(1);
+                }
+
+                task.StopTask();
+
+                return result;
+            }).ConfigureAwait(false);
+
+        if (repoBranches.Count == 0)
+        {
+            _console.MarkupLine("[yellow]No branches to prune found.[/]");
+            return;
+        }
+
+        var branchKeys = repoBranches.SelectMany(kv => kv.Value.Select(b => $"{kv.Key}|{b}")).ToList();
+
+        var selected = automatic ? branchKeys : await _console.PromptAsync(
+            new MultiSelectionPrompt<string>()
+                .Title("[green]Select branches to delete[/]")
+                .NotRequired()
+                .PageSize(20)
+                .MoreChoicesText("[grey](Use space to select, enter to confirm)[/]")
+                .InstructionsText("[grey](Press [blue]<space>[/] to select, [green]<enter>[/] to confirm)[/]")
+                .AddChoiceGroup("Select all", branchKeys)
+                .UseConverter(key =>
+                {
+                    if (key == "Select all")
+                        return key;
+
+                    var parts = key.Split('|', 2);
+                    var repo = parts[0];
+                    var branch = parts[1];
+                    return $"{_displayService.GetHierarchicalName(repo, rootDirectory)} > {branch}";
+                }));
+
+        if (selected.Count == 0)
+        {
+            _console.MarkupLine("[yellow]No branch selected.[/]");
+            return;
+        }
+
+        if (dryRun)
+        {
+            foreach (var key in selected)
+            {
+                var (repo, branch) = SplitKey(key);
+                _console.MarkupLineInterpolated($"[blue]{_displayService.GetHierarchicalName(repo, rootDirectory)} -> {branch}[/]");
+            }
+
+            _console.MarkupLine("[green]Dry run completed.[/]");
+            return;
+        }
+
+        await _console.Progress()
+            .Columns(new ProgressBarColumn
+                {
+                    CompletedStyle = new Style(foreground: Color.Green1, decoration: Decoration.Conceal | Decoration.Bold | Decoration.Invert),
+                    RemainingStyle = new Style(decoration: Decoration.Conceal),
+                    FinishedStyle = new Style(foreground: Color.Green1, decoration: Decoration.Conceal | Decoration.Bold | Decoration.Invert)
+                },
+                new PercentageColumn(),
+                new SpinnerColumn(),
+                new TaskDescriptionColumn())
+            .StartAsync(async ctx =>
+            {
+                var task = ctx.AddTask("Deleting branches...");
+                task.MaxValue = selected.Count;
+
+                foreach (var key in selected)
+                {
+                    var (repo, branch) = SplitKey(key);
+                    task.Description($"Deleting {_displayService.GetHierarchicalName(repo, rootDirectory)} -> {branch}...");
+                    try
+                    {
+                        await _gitService.DeleteLocalBranchAsync(repo, branch).ConfigureAwait(false);
+                        _console.MarkupLineInterpolated($"[green]✓ {_displayService.GetHierarchicalName(repo, rootDirectory)} -> {branch}[/]");
+                    }
+                    catch (Exception ex)
+                    {
+                        _console.MarkupLineInterpolated($"[red]✗ {_displayService.GetHierarchicalName(repo, rootDirectory)} -> {branch}: {ex.Message}[/]");
+                    }
+
+                    task.Increment(1);
+                }
+
+                task.StopTask();
+            }).ConfigureAwait(false);
+
+        _console.MarkupLine("[green]Branch pruning completed.[/]");
+    }
+
+    private static (string repo, string branch) SplitKey(string key)
+    {
+        var index = key.IndexOf('|');
+        return (key[..index], key[(index + 1)..]);
+    }
+}

--- a/GitTools/Commands/PruneBranchesCommand.cs
+++ b/GitTools/Commands/PruneBranchesCommand.cs
@@ -22,6 +22,7 @@ public sealed class PruneBranchesCommand : Command
         _console = console;
         _displayService = displayService;
 
+        Aliases.Add("pb");
 
         var rootArg = new Argument<string>("root-directory")
         {
@@ -62,14 +63,18 @@ public sealed class PruneBranchesCommand : Command
         Options.Add(automaticOption);
         Options.Add(dryRunOption);
 
-        SetAction(
-            parseResult => ExecuteAsync(
+        SetAction
+        (
+            parseResult => ExecuteAsync
+            (
                 parseResult.GetValue(rootArg)!,
                 parseResult.GetValue(mergedOption),
                 parseResult.GetValue(goneOption),
                 parseResult.GetValue(olderThanOption),
                 parseResult.GetValue(automaticOption),
-                parseResult.GetValue(dryRunOption)));
+                parseResult.GetValue(dryRunOption)
+            )
+        );
     }
 
     private async Task ExecuteAsync(string rootDirectory, bool merged, bool gone, int? olderThan, bool automatic, bool dryRun)

--- a/GitTools/Extensions/StringExtensions.cs
+++ b/GitTools/Extensions/StringExtensions.cs
@@ -1,0 +1,43 @@
+namespace GitTools.Extensions;
+
+/// <summary>
+/// Provides extension methods for string operations commonly used in Git operations.
+/// </summary>
+public static class StringExtensions
+{
+    /// <summary>
+    /// Splits a string by newlines, removing empty entries and trimming whitespace.
+    /// </summary>
+    /// <param name="value">The string to split.</param>
+    /// <returns>An array of strings split by newlines with empty entries removed and whitespace trimmed.</returns>
+    public static string[] SplitLines(this string value)
+        => value.SplitAndTrim('\n');
+
+    /// <summary>
+    /// Splits a string by the specified separator, removing empty entries and trimming whitespace.
+    /// </summary>
+    /// <param name="value">The string to split.</param>
+    /// <param name="separator">The character to split by.</param>
+    /// <returns>An array of strings split by the separator with empty entries removed and whitespace trimmed.</returns>
+    public static string[] SplitAndTrim(this string value, char separator)
+        => value.Split(separator, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>
+    /// Splits a string by the specified separator with a maximum count, removing empty entries and trimming whitespace.
+    /// </summary>
+    /// <param name="value">The string to split.</param>
+    /// <param name="separator">The character to split by.</param>
+    /// <param name="count">The maximum number of substrings to return.</param>
+    /// <returns>An array of strings split by the separator with empty entries removed and whitespace trimmed.</returns>
+    public static string[] SplitAndTrim(this string value, char separator, int count)
+        => value.Split(separator, count, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+    /// <summary>
+    /// Splits a string by the specified separator, removing empty entries only.
+    /// </summary>
+    /// <param name="value">The string to split.</param>
+    /// <param name="separator">The character to split by.</param>
+    /// <returns>An array of strings split by the separator with empty entries removed.</returns>
+    public static string[] SplitRemoveEmpty(this string value, char separator)
+        => value.Split(separator, StringSplitOptions.RemoveEmptyEntries);
+}

--- a/GitTools/Services/IGitService.cs
+++ b/GitTools/Services/IGitService.cs
@@ -275,4 +275,31 @@ public interface IGitService
     /// true if the specified branch is the current branch; otherwise, false.
     /// </returns>
     Task<bool> IsCurrentBranchAsync(string repositoryPath, string branch);
+
+    /// <summary>
+    /// Gets the name of the current branch in the specified repository.
+    /// </summary>
+    /// <param name="repositoryPath">
+    /// The path to the git repository to check.
+    /// </param>
+    /// <returns>The name of the current branch or <c>null</c> if it cannot be determined.</returns>
+    Task<string?> GetCurrentBranchAsync(string repositoryPath);
+
+    /// <summary>
+    /// Gets the list of local branches that can be pruned based on the provided criteria.
+    /// </summary>
+    /// <param name="repositoryPath">The path to the git repository.</param>
+    /// <param name="merged">Include branches already merged into HEAD.</param>
+    /// <param name="gone">Include branches whose upstream was removed.</param>
+    /// <param name="olderThanDays">Include branches older than the specified number of days.</param>
+    /// <returns>A list of branch names that can be safely pruned.</returns>
+    Task<List<string>> GetPrunableBranchesAsync(string repositoryPath, bool merged, bool gone, int? olderThanDays);
+
+    /// <summary>
+    /// Deletes a local branch from the specified repository.
+    /// </summary>
+    /// <param name="repositoryPath">The path to the git repository.</param>
+    /// <param name="branch">The branch to delete.</param>
+    /// <param name="force">Use force deletion.</param>
+    Task DeleteLocalBranchAsync(string repositoryPath, string branch, bool force = false);
 }

--- a/GitTools/Services/TagValidationService.cs
+++ b/GitTools/Services/TagValidationService.cs
@@ -1,3 +1,5 @@
+using GitTools.Extensions;
+
 namespace GitTools.Services;
 
 /// <summary>
@@ -12,7 +14,7 @@ public sealed class TagValidationService : ITagValidationService
             return [];
 
         return [.. tagsInput
-            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .SplitAndTrim(',')
             .Where(tag => !string.IsNullOrWhiteSpace(tag))];
     }
 

--- a/GitTools/Startup.cs
+++ b/GitTools/Startup.cs
@@ -79,6 +79,7 @@ public static class Startup
         services.AddSingleton<BulkBackupCommand>();
         services.AddSingleton<BulkRestoreCommand>();
         services.AddSingleton<SynchronizeCommand>();
+        services.AddSingleton<PruneBranchesCommand>();
         services.AddSingleton<ITagSearchService, TagSearchService>();
         services.AddSingleton<ITagValidationService, TagValidationService>();
         services.AddSingleton<IConsoleDisplayService, ConsoleDisplayService>();
@@ -127,6 +128,7 @@ public static class Startup
         var bulkBackupCommand = serviceProvider.GetRequiredService<BulkBackupCommand>();
         var bulkRestoreCommand = serviceProvider.GetRequiredService<BulkRestoreCommand>();
         var outdatedCommand = serviceProvider.GetRequiredService<SynchronizeCommand>();
+        var pruneBranchesCommand = serviceProvider.GetRequiredService<PruneBranchesCommand>();
 
         rootCommand.Subcommands.Add(tagRemoveCommand);
         rootCommand.Subcommands.Add(tagListCommand);
@@ -134,6 +136,7 @@ public static class Startup
         rootCommand.Subcommands.Add(bulkBackupCommand);
         rootCommand.Subcommands.Add(bulkRestoreCommand);
         rootCommand.Subcommands.Add(outdatedCommand);
+        rootCommand.Subcommands.Add(pruneBranchesCommand);
 
         return rootCommand;
     }

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   - [Bulk Backup (bkp)](#bulk-backup-bkp)
   - [Bulk Restore (restore)](#bulk-restore-restore)
   - [Synchronize (sync)](#synchronize-sync)
+  - [Prune Branches (prune-branches)](#prune-branches-prune-branches)
   - [Build](#build)
 - [Code Coverage](#code-coverage)
 - [AOT Compilation](#aot-compilation)
@@ -263,6 +264,23 @@ Use `--automatic` to run without user interaction, automatically selecting all o
 Use `--push-untracked` to also push any new local branches to the remote repository during synchronization.
 
 Use `--include-submodules false` to exclude Git submodules from the scanning process.
+
+### Prune Branches (prune-branches)
+
+Clean up stale local branches across multiple repositories.
+
+```sh
+GitTools prune-branches <root-directory> [--merged] [--gone] [--older-than <days>] [--automatic] [--dry-run]
+```
+
+#### Prune Options
+
+- `root-directory` (required): Root directory to scan for Git repositories.
+- `--merged`: Include branches already merged into HEAD (default when no other option is provided).
+- `--gone`: Include branches whose upstream was deleted on the remote.
+- `--older-than`: Include branches whose last commit is older than the specified number of days.
+- `--automatic`, `-a`: Delete all matched branches without prompting.
+- `--dry-run`: Show the branches that would be deleted without actually deleting them.
 
 ## Build
 


### PR DESCRIPTION
## Summary
- add prune-branches command with interactive pruning logic
- implement git service helpers for pruning branches
- support getting current branch and deleting local branches
- register the new command
- add unit tests
- document prune-branches in README

## Testing
- `dotnet build`
- `dotnet test`
- `./generate-coverage.sh`
- `dotnet publish GitTools/GitTools.csproj -c Release`


------
https://chatgpt.com/codex/tasks/task_e_685ff49a92b88325a2ea05547a86acf8